### PR TITLE
[codex] add docker scheduled collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY src ./src
+COPY config ./config
+COPY data/pricing-litellm.json data/pricing-openrouter.json ./data/
 COPY index.html vite.config.js ./
 RUN npm run build && npm prune --omit=dev
 

--- a/README.en.md
+++ b/README.en.md
@@ -132,18 +132,22 @@ INGEST_TOKEN="your-secret-token" docker compose up -d
 
 Data is written to the mounted `./data` volume. **Local log collection should run on the host**, as agent session files live in the host user's home directory.
 
-### Scheduled Collection in Docker
+### Scheduled Collection
 
-If you want Docker to run collection on a schedule, mount the host user's AI tool log directory into the collector container. `docker-compose.yml` includes an optional `collector` profile. It runs collection every 5 minutes by default and writes to the same `./data/usage.sqlite` database.
+The server has built-in scheduled collection. It is disabled by default. Once enabled, the server runs local collection at the configured interval; Docker and plain `npm run serve` use the same scheduler.
+
+When collecting from Docker, mount the host user's AI tool log directory into the container. `docker-compose.yml` includes the required environment variables and mount. The default interval is 5 minutes and data is written to the same `./data/usage.sqlite` database.
 
 Linux/macOS:
 
 ```bash
 export INGEST_TOKEN="your-secret-token"
 export AI_TOKEN_DASHBOARD_COLLECTOR_HOME="$HOME"
+export SCHEDULED_COLLECT_ENABLED=true
+export SCHEDULED_COLLECT_RUN_ON_START=true
 export COLLECT_DEVICE="my-laptop"
-export COLLECT_INTERVAL_SECONDS=300
-docker compose --profile collector up -d
+export SCHEDULED_COLLECT_INTERVAL_SECONDS=300
+docker compose up -d
 ```
 
 PowerShell:
@@ -151,16 +155,19 @@ PowerShell:
 ```powershell
 $env:INGEST_TOKEN = "your-secret-token"
 $env:AI_TOKEN_DASHBOARD_COLLECTOR_HOME = $env:USERPROFILE
+$env:SCHEDULED_COLLECT_ENABLED = "true"
+$env:SCHEDULED_COLLECT_RUN_ON_START = "true"
 $env:COLLECT_DEVICE = "my-laptop"
-$env:COLLECT_INTERVAL_SECONDS = "300"
-docker compose --profile collector up -d
+$env:SCHEDULED_COLLECT_INTERVAL_SECONDS = "300"
+docker compose up -d
 ```
 
 Notes:
 
-- Without `--profile collector`, Docker only starts the dashboard/ingest server and does not collect automatically.
+- Without `SCHEDULED_COLLECT_ENABLED`, the server only starts the dashboard/ingest service and does not collect automatically.
 - `AI_TOKEN_DASHBOARD_COLLECTOR_HOME` must point to the host user directory that contains logs such as `.codex`, `.claude`, `.hermes`, and `.local/share/opencode`.
-- If AI tool data lives across multiple directories, prefer running `npm run collect` from a host scheduler, or provide a custom collector config with `AI_TOKEN_DASHBOARD_CONFIG`.
+- Outside Docker, you can also configure `enabled`, `intervalSeconds`, `runOnStart`, and `device` under `scheduledCollect` in `config/collectors.json`.
+- If AI tool data lives across multiple directories, provide a custom collector config with `AI_TOKEN_DASHBOARD_CONFIG`.
 
 ---
 
@@ -172,6 +179,10 @@ Notes:
 | `API_PORT` | `4173` | API server port used by `npm run dev` |
 | `DB_PATH` | `data/usage.sqlite` | SQLite database path |
 | `INGEST_TOKEN` | _(unset)_ | If set, `/api/ingest` requires `Authorization: Bearer <token>` |
+| `SCHEDULED_COLLECT_ENABLED` | `false` | Enable the built-in scheduled collector |
+| `SCHEDULED_COLLECT_INTERVAL_SECONDS` | `300` | Scheduled collection interval in seconds, minimum 10 seconds |
+| `SCHEDULED_COLLECT_RUN_ON_START` | `false` | Run one collection shortly after server startup |
+| `COLLECT_DEVICE` | hostname | Device label stored with scheduled collection records |
 
 ### Pricing Caches
 

--- a/README.en.md
+++ b/README.en.md
@@ -132,6 +132,36 @@ INGEST_TOKEN="your-secret-token" docker compose up -d
 
 Data is written to the mounted `./data` volume. **Local log collection should run on the host**, as agent session files live in the host user's home directory.
 
+### Scheduled Collection in Docker
+
+If you want Docker to run collection on a schedule, mount the host user's AI tool log directory into the collector container. `docker-compose.yml` includes an optional `collector` profile. It runs collection every 5 minutes by default and writes to the same `./data/usage.sqlite` database.
+
+Linux/macOS:
+
+```bash
+export INGEST_TOKEN="your-secret-token"
+export AI_TOKEN_DASHBOARD_COLLECTOR_HOME="$HOME"
+export COLLECT_DEVICE="my-laptop"
+export COLLECT_INTERVAL_SECONDS=300
+docker compose --profile collector up -d
+```
+
+PowerShell:
+
+```powershell
+$env:INGEST_TOKEN = "your-secret-token"
+$env:AI_TOKEN_DASHBOARD_COLLECTOR_HOME = $env:USERPROFILE
+$env:COLLECT_DEVICE = "my-laptop"
+$env:COLLECT_INTERVAL_SECONDS = "300"
+docker compose --profile collector up -d
+```
+
+Notes:
+
+- Without `--profile collector`, Docker only starts the dashboard/ingest server and does not collect automatically.
+- `AI_TOKEN_DASHBOARD_COLLECTOR_HOME` must point to the host user directory that contains logs such as `.codex`, `.claude`, `.hermes`, and `.local/share/opencode`.
+- If AI tool data lives across multiple directories, prefer running `npm run collect` from a host scheduler, or provide a custom collector config with `AI_TOKEN_DASHBOARD_CONFIG`.
+
 ---
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -132,6 +132,36 @@ INGEST_TOKEN="your-secret-token" docker compose up -d
 
 数据写入挂载的 `./data` 目录。**本机日志采集建议在宿主机执行**，因为各 Agent/CLI 的会话文件保存在宿主机用户目录中。
 
+### Docker 定时采集
+
+如果确实希望由 Docker 容器定时采集，需要把宿主机的 AI 工具日志目录挂载给 collector。`docker-compose.yml` 内置了可选的 `collector` profile，默认每 5 分钟运行一次采集，并写入同一个 `./data/usage.sqlite`。
+
+Linux/macOS 示例：
+
+```bash
+export INGEST_TOKEN="your-secret-token"
+export AI_TOKEN_DASHBOARD_COLLECTOR_HOME="$HOME"
+export COLLECT_DEVICE="my-laptop"
+export COLLECT_INTERVAL_SECONDS=300
+docker compose --profile collector up -d
+```
+
+PowerShell 示例：
+
+```powershell
+$env:INGEST_TOKEN = "your-secret-token"
+$env:AI_TOKEN_DASHBOARD_COLLECTOR_HOME = $env:USERPROFILE
+$env:COLLECT_DEVICE = "my-laptop"
+$env:COLLECT_INTERVAL_SECONDS = "300"
+docker compose --profile collector up -d
+```
+
+注意：
+
+- 不启用 `--profile collector` 时，只会启动看板和 ingest 服务，不会自动采集。
+- `AI_TOKEN_DASHBOARD_COLLECTOR_HOME` 必须指向保存 `.codex`、`.claude`、`.hermes`、`.local/share/opencode` 等日志的宿主机用户目录。
+- 如果 AI 工具数据分散在多个目录，建议继续在宿主机用系统任务运行 `npm run collect`，或通过 `AI_TOKEN_DASHBOARD_CONFIG` 提供自定义 collector 配置。
+
 ---
 
 ## 配置项

--- a/README.md
+++ b/README.md
@@ -132,18 +132,22 @@ INGEST_TOKEN="your-secret-token" docker compose up -d
 
 数据写入挂载的 `./data` 目录。**本机日志采集建议在宿主机执行**，因为各 Agent/CLI 的会话文件保存在宿主机用户目录中。
 
-### Docker 定时采集
+### 定时采集
 
-如果确实希望由 Docker 容器定时采集，需要把宿主机的 AI 工具日志目录挂载给 collector。`docker-compose.yml` 内置了可选的 `collector` profile，默认每 5 分钟运行一次采集，并写入同一个 `./data/usage.sqlite`。
+服务内置定时采集能力，默认关闭。开启后，服务会按配置间隔自动执行一次本机采集；Docker 和普通 `npm run serve` 启动走的是同一套逻辑。
+
+如果用 Docker 采集，需要把宿主机的 AI 工具日志目录挂载进容器。`docker-compose.yml` 已内置相关环境变量和挂载，默认每 5 分钟运行一次采集，并写入同一个 `./data/usage.sqlite`。
 
 Linux/macOS 示例：
 
 ```bash
 export INGEST_TOKEN="your-secret-token"
 export AI_TOKEN_DASHBOARD_COLLECTOR_HOME="$HOME"
+export SCHEDULED_COLLECT_ENABLED=true
+export SCHEDULED_COLLECT_RUN_ON_START=true
 export COLLECT_DEVICE="my-laptop"
-export COLLECT_INTERVAL_SECONDS=300
-docker compose --profile collector up -d
+export SCHEDULED_COLLECT_INTERVAL_SECONDS=300
+docker compose up -d
 ```
 
 PowerShell 示例：
@@ -151,16 +155,19 @@ PowerShell 示例：
 ```powershell
 $env:INGEST_TOKEN = "your-secret-token"
 $env:AI_TOKEN_DASHBOARD_COLLECTOR_HOME = $env:USERPROFILE
+$env:SCHEDULED_COLLECT_ENABLED = "true"
+$env:SCHEDULED_COLLECT_RUN_ON_START = "true"
 $env:COLLECT_DEVICE = "my-laptop"
-$env:COLLECT_INTERVAL_SECONDS = "300"
-docker compose --profile collector up -d
+$env:SCHEDULED_COLLECT_INTERVAL_SECONDS = "300"
+docker compose up -d
 ```
 
 注意：
 
-- 不启用 `--profile collector` 时，只会启动看板和 ingest 服务，不会自动采集。
+- 不开启 `SCHEDULED_COLLECT_ENABLED` 时，只会启动看板和 ingest 服务，不会自动采集。
 - `AI_TOKEN_DASHBOARD_COLLECTOR_HOME` 必须指向保存 `.codex`、`.claude`、`.hermes`、`.local/share/opencode` 等日志的宿主机用户目录。
-- 如果 AI 工具数据分散在多个目录，建议继续在宿主机用系统任务运行 `npm run collect`，或通过 `AI_TOKEN_DASHBOARD_CONFIG` 提供自定义 collector 配置。
+- 非 Docker 场景也可以在 `config/collectors.json` 的 `scheduledCollect` 中配置 `enabled`、`intervalSeconds`、`runOnStart` 和 `device`。
+- 如果 AI 工具数据分散在多个目录，可以通过 `AI_TOKEN_DASHBOARD_CONFIG` 提供自定义 collector 配置。
 
 ---
 
@@ -172,6 +179,10 @@ docker compose --profile collector up -d
 | `API_PORT` | `4173` | `npm run dev` 中 API 服务端口 |
 | `DB_PATH` | `data/usage.sqlite` | SQLite 数据库路径 |
 | `INGEST_TOKEN` | _未设置_ | 设置后，`/api/ingest` 接口需要 `Authorization: Bearer <token>` |
+| `SCHEDULED_COLLECT_ENABLED` | `false` | 是否启用服务内置定时采集 |
+| `SCHEDULED_COLLECT_INTERVAL_SECONDS` | `300` | 定时采集间隔秒数，最低 10 秒 |
+| `SCHEDULED_COLLECT_RUN_ON_START` | `false` | 服务启动后是否立即采集一次 |
+| `COLLECT_DEVICE` | 主机名 | 定时采集写入记录的设备标签 |
 
 ### 定价缓存
 

--- a/config/collectors.json
+++ b/config/collectors.json
@@ -1,4 +1,10 @@
 {
+  "scheduledCollect": {
+    "enabled": false,
+    "intervalSeconds": 300,
+    "runOnStart": false,
+    "device": null
+  },
   "collectors": {
     "claude": {
       "roots": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     build: .
     profiles:
       - collector
+    depends_on:
+      - ai-token-dashboard
     environment:
       HOME: /collector-home
       DB_PATH: /app/data/usage.sqlite
@@ -25,6 +27,7 @@ services:
       - sh
       - -c
       - |
+        sleep 5
         while true; do
           echo "[collector] run"
           date -Iseconds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,32 +6,11 @@ services:
     environment:
       PORT: "4173"
       INGEST_TOKEN: "${INGEST_TOKEN:?Set INGEST_TOKEN before starting the hub}"
-    volumes:
-      - ./data:/app/data
-
-  collector:
-    build: .
-    profiles:
-      - collector
-    depends_on:
-      - ai-token-dashboard
-    environment:
       HOME: /collector-home
-      DB_PATH: /app/data/usage.sqlite
+      SCHEDULED_COLLECT_ENABLED: "${SCHEDULED_COLLECT_ENABLED:-false}"
+      SCHEDULED_COLLECT_INTERVAL_SECONDS: "${SCHEDULED_COLLECT_INTERVAL_SECONDS:-${COLLECT_INTERVAL_SECONDS:-300}}"
+      SCHEDULED_COLLECT_RUN_ON_START: "${SCHEDULED_COLLECT_RUN_ON_START:-false}"
       COLLECT_DEVICE: "${COLLECT_DEVICE:-docker-collector}"
-      COLLECT_INTERVAL_SECONDS: "${COLLECT_INTERVAL_SECONDS:-300}"
     volumes:
       - ./data:/app/data
       - "${AI_TOKEN_DASHBOARD_COLLECTOR_HOME:-.}:/collector-home:ro"
-    command:
-      - sh
-      - -c
-      - |
-        sleep 5
-        while true; do
-          echo "[collector] run"
-          date -Iseconds
-          node src/collect.mjs --device "${COLLECT_DEVICE:-docker-collector}" --db /app/data/usage.sqlite
-          sleep "${COLLECT_INTERVAL_SECONDS:-300}"
-        done
-    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,27 @@ services:
       INGEST_TOKEN: "${INGEST_TOKEN:?Set INGEST_TOKEN before starting the hub}"
     volumes:
       - ./data:/app/data
+
+  collector:
+    build: .
+    profiles:
+      - collector
+    environment:
+      HOME: /collector-home
+      DB_PATH: /app/data/usage.sqlite
+      COLLECT_DEVICE: "${COLLECT_DEVICE:-docker-collector}"
+      COLLECT_INTERVAL_SECONDS: "${COLLECT_INTERVAL_SECONDS:-300}"
+    volumes:
+      - ./data:/app/data
+      - "${AI_TOKEN_DASHBOARD_COLLECTOR_HOME:-.}:/collector-home:ro"
+    command:
+      - sh
+      - -c
+      - |
+        while true; do
+          echo "[collector] run"
+          date -Iseconds
+          node src/collect.mjs --device "${COLLECT_DEVICE:-docker-collector}" --db /app/data/usage.sqlite
+          sleep "${COLLECT_INTERVAL_SECONDS:-300}"
+        done
+    restart: unless-stopped

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -7,6 +7,7 @@ export const defaultDbPath = resolve(process.cwd(), 'data', 'usage.sqlite');
 export function openDb(dbPath = defaultDbPath) {
   mkdirSync(dirname(dbPath), { recursive: true });
   const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA busy_timeout = 10000');
   db.exec('PRAGMA journal_mode = WAL');
   db.exec('PRAGMA foreign_keys = ON');
   initSchema(db);

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -4,6 +4,7 @@ import { createServer } from 'node:http';
 import { extname, join, resolve } from 'node:path';
 import { URL } from 'node:url';
 import { openDb, recordRun, upsertDaily, upsertSession } from './db.mjs';
+import { loadCollectorConfig } from './collector-config.mjs';
 
 const port = Number(process.env.PORT || 4173);
 const staticDir = existsSync(resolve(process.cwd(), 'dist'))
@@ -32,6 +33,7 @@ const server = createServer((req, res) => {
 
 server.listen(port, () => {
   console.log(`AI Token Dashboard: http://localhost:${port}`);
+  startScheduledCollect();
 });
 
 function handleApi(req, url, res) {
@@ -187,12 +189,21 @@ function handleCollect(req, res) {
     return;
   }
 
+  startCollection({ reason: 'manual' });
+  sendJson(res, collectionState, 202);
+}
+
+function startCollection({ reason = 'manual' } = {}) {
   if (activeCollection) {
-    sendJson(res, collectionState, 202);
-    return;
+    return false;
   }
 
-  const child = spawn(process.execPath, ['src/collect.mjs'], {
+  const args = ['src/collect.mjs'];
+  const device = collectionDevice();
+  if (device) args.push('--device', device);
+  if (process.env.DB_PATH) args.push('--db', process.env.DB_PATH);
+
+  const child = spawn(process.execPath, args, {
     cwd: process.cwd(),
     env: process.env,
     windowsHide: true
@@ -204,7 +215,7 @@ function handleCollect(req, res) {
   const startedAt = new Date().toISOString();
   collectionState = {
     status: 'running',
-    message: '正在采集本机用量',
+    message: reason === 'scheduled' ? '正在定时采集本机用量' : '正在采集本机用量',
     startedAt,
     finishedAt: null,
     exitCode: null,
@@ -241,7 +252,53 @@ function handleCollect(req, res) {
     };
   });
 
-  sendJson(res, collectionState, 202);
+  return true;
+}
+
+function startScheduledCollect() {
+  const schedule = scheduledCollectConfig();
+  if (!schedule.enabled) return;
+
+  console.log(`[collect:schedule] enabled interval=${schedule.intervalSeconds}s runOnStart=${schedule.runOnStart}`);
+
+  const run = () => {
+    const started = startCollection({ reason: 'scheduled' });
+    if (!started) console.log('[collect:schedule] skipped because a collection is already running');
+  };
+
+  if (schedule.runOnStart) {
+    setTimeout(run, 1000);
+  }
+
+  setInterval(run, schedule.intervalSeconds * 1000);
+}
+
+function scheduledCollectConfig() {
+  const config = loadCollectorConfig().scheduledCollect || {};
+  const enabled = envBool('SCHEDULED_COLLECT_ENABLED', config.enabled ?? false);
+  const intervalSeconds = Math.max(
+    10,
+    envNumber('SCHEDULED_COLLECT_INTERVAL_SECONDS',
+      envNumber('COLLECT_INTERVAL_SECONDS', config.intervalSeconds ?? 300))
+  );
+  const runOnStart = envBool('SCHEDULED_COLLECT_RUN_ON_START', config.runOnStart ?? false);
+  return { enabled, intervalSeconds, runOnStart };
+}
+
+function collectionDevice() {
+  const config = loadCollectorConfig().scheduledCollect || {};
+  return process.env.COLLECT_DEVICE || process.env.SCHEDULED_COLLECT_DEVICE || config.device || null;
+}
+
+function envBool(name, fallback) {
+  const value = process.env[name];
+  if (value == null || value === '') return Boolean(fallback);
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
+
+function envNumber(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : Number(fallback);
 }
 
 async function handleIngest(req, res) {


### PR DESCRIPTION
## Summary

Adds built-in scheduled collection to the server, intended to address #1.

Scheduled collection is now an application capability rather than a Docker-only shell loop. It is disabled by default and can be enabled either from `config/collectors.json` or environment variables. Docker and plain `npm run serve` use the same scheduler.

## Changes

- Add `scheduledCollect` config with `enabled`, `intervalSeconds`, `runOnStart`, and `device`.
- Add server-side scheduling that reuses the same collection path as the dashboard's manual Collect button.
- Support environment overrides: `SCHEDULED_COLLECT_ENABLED`, `SCHEDULED_COLLECT_INTERVAL_SECONDS`, `SCHEDULED_COLLECT_RUN_ON_START`, and `COLLECT_DEVICE`.
- Simplify `docker-compose.yml`: remove the separate collector service and shell loop; Docker now only passes scheduler config and mounts the host user directory.
- Copy collector configuration and bundled pricing caches into the Docker image so scheduled collection can run inside the server container.
- Add SQLite `busy_timeout` to reduce lock races during scheduled/manual collection.
- Document scheduled collection for both Docker and non-Docker usage.

## Validation

- `npm run build`
- `docker compose config`
- `docker compose build --progress plain`
- Plain server validation: `node src/server.mjs` with `SCHEDULED_COLLECT_ENABLED=true`, `SCHEDULED_COLLECT_RUN_ON_START=true`, `SCHEDULED_COLLECT_INTERVAL_SECONDS=60`, and a temporary `DB_PATH`; verified 6 collection run rows for `verify-service-scheduler`.
- Docker validation: `SCHEDULED_COLLECT_ENABLED=true`, `SCHEDULED_COLLECT_RUN_ON_START=true`, `SCHEDULED_COLLECT_INTERVAL_SECONDS=60`, `docker compose up -d`; verified one dashboard container, `/api/data` returned 200, and collection rows were written for `verify-docker-scheduler` at `2026-06-08T06:59:54.327Z` and `2026-06-08T07:00:54.469Z`.