### PR TITLE
[codex] add precise time filtering

### DIFF
--- a/src/client/dashboard/App.jsx
+++ b/src/client/dashboard/App.jsx
@@ -32,7 +32,7 @@ export function App() {
       })
       .then(data => {
         // Assign colors to sources dynamically
-        const sourceNames = [...new Set(data.daily.map(r => r.source))];
+        const sourceNames = [...new Set([...(data.daily || []), ...(data.time || [])].map(r => r.source))];
         const SOURCES = sourceNames.map((name, i) => ({
           name,
           color: U.getSourceColor(name)
@@ -50,6 +50,8 @@ export function App() {
 
         setM({
           ...data,
+          daily: data.daily || [],
+          time: data.time || [],
           SOURCES,
           HOURLY,
           today: U.daysAgo(0)
@@ -176,6 +178,9 @@ function Dashboard({ M, refreshing, collecting, collectStatus, onRefresh, onColl
     rangeId: '30d',
     startDate: U.daysAgo(29),
     endDate: U.daysAgo(0),
+    precise: false,
+    startDateTime: U.startOfDayLocal(U.daysAgo(29)),
+    endDateTime: U.endOfDayLocal(U.daysAgo(0)),
     sources: new Set(),
     devices: new Set(),
     models: new Set(),
@@ -187,23 +192,29 @@ function Dashboard({ M, refreshing, collecting, collectStatus, onRefresh, onColl
   const [focusedSource, setFocusedSource] = useState(null);
 
   // Build option lists
-  const allSources = useMemo(() => Array.from(new Set(M.daily.map(r => r.source))), [M.daily]);
-  const allDevices = useMemo(() => Array.from(new Set(M.daily.map(r => r.device))), [M.daily]);
-  const allModels  = useMemo(() => Array.from(new Set(M.daily.map(r => r.model))).filter(Boolean), [M.daily]);
+  const filterBaseRows = filters.precise && M.time.length ? M.time : M.daily;
+  const allSources = useMemo(() => Array.from(new Set(filterBaseRows.map(r => r.source))), [filterBaseRows]);
+  const allDevices = useMemo(() => Array.from(new Set(filterBaseRows.map(r => r.device))), [filterBaseRows]);
+  const allModels  = useMemo(() => Array.from(new Set(filterBaseRows.map(r => r.model))).filter(Boolean), [filterBaseRows]);
   const availableRange = useMemo(() => {
     const dates = M.daily.map(r => r.usageDate).filter(Boolean).sort();
+    const times = M.time.map(r => r.eventTime).filter(Boolean).sort();
     return {
       startDate: dates[0] || U.daysAgo(0),
-      endDate: dates[dates.length - 1] || U.daysAgo(0)
+      endDate: dates[dates.length - 1] || U.daysAgo(0),
+      startDateTime: times[0] ? U.toDateTimeLocalValue(new Date(times[0])) : U.startOfDayLocal(dates[0] || U.daysAgo(0)),
+      endDateTime: times[times.length - 1] ? U.toDateTimeLocalValue(new Date(times[times.length - 1])) : U.endOfDayLocal(dates[dates.length - 1] || U.daysAgo(0))
     };
-  }, [M.daily]);
+  }, [M.daily, M.time]);
 
   // ───── Filtered data ─────
   const filtered = useMemo(() => {
     const effective = { ...filters };
     if (focusedSource) effective.sources = new Set([focusedSource]);
-    return U.filterDaily(M.daily, effective);
-  }, [filters, focusedSource, M.daily]);
+    return filters.precise && M.time.length
+      ? U.filterTime(M.time, effective)
+      : U.filterDaily(M.daily, effective);
+  }, [filters, focusedSource, M.daily, M.time]);
 
   const totals = useMemo(() => U.aggregateTotals(filtered), [filtered]);
 
@@ -216,13 +227,31 @@ function Dashboard({ M, refreshing, collecting, collectStatus, onRefresh, onColl
   // ───── Comparison period ─────
   const compareData = useMemo(() => {
     if (!filters.compare) return { rows: null, dates: null, totals: null };
+    if (filters.precise && M.time.length) {
+      const startMs = new Date(filters.startDateTime).getTime();
+      const endMs = new Date(filters.endDateTime).getTime();
+      if (Number.isNaN(startMs) || Number.isNaN(endMs) || endMs < startMs) {
+        return { rows: null, dates: null, totals: null };
+      }
+      const span = endMs - startMs;
+      const prevEnd = new Date(startMs - 60_000);
+      const prevStart = new Date(prevEnd.getTime() - span);
+      const startDateTime = U.toDateTimeLocalValue(prevStart);
+      const endDateTime = U.toDateTimeLocalValue(prevEnd);
+      const rows = U.filterTime(M.time, { ...filters, startDateTime, endDateTime });
+      return {
+        rows,
+        dates: U.rangeDates(startDateTime.slice(0, 10), endDateTime.slice(0, 10)),
+        totals: U.aggregateTotals(rows)
+      };
+    }
     const days = dates.length;
     const endStr = U.addDays(filters.startDate, -1);
     const startStr = U.addDays(endStr, -(days - 1));
     const rows  = U.filterDaily(M.daily, { ...filters, startDate: startStr, endDate: endStr });
     const cDates = U.rangeDates(startStr, endStr);
     return { rows, dates: cDates, totals: U.aggregateTotals(rows) };
-  }, [filters, dates.length, M.daily]);
+  }, [filters, dates.length, M.daily, M.time]);
 
   // ───── Sparklines ─────
   const dailyTotalsByDay = useMemo(() => {
@@ -256,8 +285,11 @@ function Dashboard({ M, refreshing, collecting, collectStatus, onRefresh, onColl
 
   // ───── Export ─────
   const onExportAll = () => {
-    U.downloadCSV(`tokens-daily-${filters.startDate}-${filters.endDate}.csv`, filtered, [
-      { title: 'date',             field: 'usageDate' },
+    const rangeName = filters.precise
+      ? `${filters.startDateTime}-${filters.endDateTime}`.replace(/[:T]/g, '-')
+      : `${filters.startDate}-${filters.endDate}`;
+    U.downloadCSV(`tokens-${filters.precise ? 'time' : 'daily'}-${rangeName}.csv`, filtered, [
+      { title: filters.precise ? 'time' : 'date', field: filters.precise ? 'eventTime' : 'usageDate' },
       { title: 'source',           field: 'source' },
       { title: 'device',           field: 'device' },
       { title: 'model',            field: 'model' },

--- a/src/client/dashboard/components-charts.jsx
+++ b/src/client/dashboard/components-charts.jsx
@@ -69,6 +69,20 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
     ? compareDates.map(d => compareByDate.get(d) || 0)
     : null;
 
+  const topSourceByDate = useMemo(() => {
+    const top = new Map();
+    for (const d of dates) {
+      for (let i = sources.length - 1; i >= 0; i -= 1) {
+        const src = sources[i];
+        if ((byKey.get(`${d}::${src}`) || 0) > 0) {
+          top.set(d, src);
+          break;
+        }
+      }
+    }
+    return top;
+  }, [byKey, dates, sources]);
+
   // Trend rolling-avg (7-day) for line mode
   const rolling = (() => {
     const arr = [];
@@ -92,12 +106,18 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
         type: 'bar',
         stack: mode === 'stacked' ? 'total' : undefined,
         barMaxWidth: 24,
-        itemStyle: {
-          color: palette[i],
-          borderRadius: mode === 'stacked' && i === sources.length - 1 ? [4, 4, 0, 0] : (mode === 'bar' ? [3, 3, 0, 0] : 0)
-        },
+        itemStyle: { color: palette[i] },
         emphasis: { focus: 'series' },
-        data: dates.map(d => byKey.get(`${d}::${src}`) || 0)
+        data: dates.map(d => {
+          const value = byKey.get(`${d}::${src}`) || 0;
+          if (mode === 'bar') return { value, itemStyle: { borderRadius: [3, 3, 0, 0] } };
+          return {
+            value,
+            itemStyle: {
+              borderRadius: value > 0 && topSourceByDate.get(d) === src ? [4, 4, 0, 0] : 0
+            }
+          };
+        })
       });
     });
   } else if (mode === 'line') {

--- a/src/client/dashboard/components-top.jsx
+++ b/src/client/dashboard/components-top.jsx
@@ -66,6 +66,7 @@ function Topbar({ lastSync, onRefresh, refreshing, onCollect, collecting, collec
 // ───────────────────────────────────────────────────────────────
 function FilterBar({ f, setF, allSources, allDevices, allModels, availableRange, onExport }) {
   const RANGES = [
+    { id: 'today', label: '今天', days: 1  },
     { id: '7d',  label: '7 天',  days: 7  },
     { id: '14d', label: '14 天', days: 14 },
     { id: '30d', label: '30 天', days: 30 },

--- a/src/client/dashboard/components-top.jsx
+++ b/src/client/dashboard/components-top.jsx
@@ -75,10 +75,35 @@ function FilterBar({ f, setF, allSources, allDevices, allModels, availableRange,
 
   const setRange = (r) => {
     if (r.id === 'all') {
-      setF({ ...f, rangeId: r.id, startDate: availableRange.startDate, endDate: availableRange.endDate });
+      setF({
+        ...f,
+        rangeId: r.id,
+        startDate: availableRange.startDate,
+        endDate: availableRange.endDate,
+        precise: false,
+        startDateTime: availableRange.startDateTime || U.startOfDayLocal(availableRange.startDate),
+        endDateTime: availableRange.endDateTime || U.endOfDayLocal(availableRange.endDate)
+      });
       return;
     }
-    setF({ ...f, rangeId: r.id, startDate: U.daysAgo(r.days - 1), endDate: U.daysAgo(0) });
+    const startDate = U.daysAgo(r.days - 1);
+    const endDate = U.daysAgo(0);
+    setF({
+      ...f,
+      rangeId: r.id,
+      startDate,
+      endDate,
+      precise: false,
+      startDateTime: U.startOfDayLocal(startDate),
+      endDateTime: U.endOfDayLocal(endDate)
+    });
+  };
+
+  const setPreciseTime = (key, value) => {
+    const next = { ...f, precise: true, rangeId: 'custom', [key]: value };
+    if (key === 'startDateTime' && value) next.startDate = value.slice(0, 10);
+    if (key === 'endDateTime' && value) next.endDate = value.slice(0, 10);
+    setF(next);
   };
 
   const toggleSet = (key, value) => {
@@ -104,6 +129,17 @@ function FilterBar({ f, setF, allSources, allDevices, allModels, availableRange,
                 className={`chip ${f.rangeId === r.id ? 'active' : ''}`}
                 onClick={() => setRange(r)}>{r.label}</button>
             ))}
+          </div>
+          <div className={`time-range ${f.precise ? 'active' : ''}`}>
+            <DateTimeField
+              value={f.startDateTime || ''}
+              onChange={value => setPreciseTime('startDateTime', value)}
+              title="开始时间" />
+            <span className="time-sep">至</span>
+            <DateTimeField
+              value={f.endDateTime || ''}
+              onChange={value => setPreciseTime('endDateTime', value)}
+              title="结束时间" />
           </div>
         </div>
 
@@ -162,6 +198,137 @@ function FilterBar({ f, setF, allSources, allDevices, allModels, availableRange,
       </div>
     </div>
   );
+}
+
+function DateTimeField({ value, onChange, title }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+  const parsed = useMemo(() => parseDateTimeValue(value), [value]);
+  const [viewMonth, setViewMonth] = useState(() => new Date(parsed.year, parsed.month - 1, 1));
+
+  useEffect(() => {
+    setViewMonth(new Date(parsed.year, parsed.month - 1, 1));
+  }, [parsed.year, parsed.month]);
+
+  useEffect(() => {
+    const onDocClick = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, []);
+
+  const commit = (patch) => {
+    const next = { ...parsed, ...patch };
+    onChange(formatDateTimeValue(next));
+  };
+
+  const moveMonth = (delta) => {
+    setViewMonth(prev => new Date(prev.getFullYear(), prev.getMonth() + delta, 1));
+  };
+
+  const days = monthCells(viewMonth);
+  const monthLabel = `${viewMonth.getFullYear()}年${String(viewMonth.getMonth() + 1).padStart(2, '0')}月`;
+
+  return (
+    <div className="dt-field" ref={ref}>
+      <button className="time-trigger" type="button" title={title} onClick={() => setOpen(o => !o)}>
+        <span>{displayDateTime(value)}</span>
+        <svg className="time-icon" viewBox="0 0 16 16" fill="none">
+          <path d="M4 2.5v2M12 2.5v2M3 6.5h10M4 4h8c.83 0 1.5.67 1.5 1.5v6c0 .83-.67 1.5-1.5 1.5H4c-.83 0-1.5-.67-1.5-1.5v-6C2.5 4.67 3.17 4 4 4Z" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+        </svg>
+      </button>
+
+      {open && (
+        <div className="dt-popover">
+          <div className="dt-head">
+            <button className="dt-nav" type="button" onClick={() => moveMonth(-1)}>‹</button>
+            <div className="dt-title">{monthLabel}</div>
+            <button className="dt-nav" type="button" onClick={() => moveMonth(1)}>›</button>
+          </div>
+          <div className="dt-week">
+            {['一', '二', '三', '四', '五', '六', '日'].map(d => <span key={d}>{d}</span>)}
+          </div>
+          <div className="dt-grid">
+            {days.map(day => (
+              <button
+                key={day.key}
+                type="button"
+                className={`dt-day ${day.inMonth ? '' : 'muted'} ${day.value === parsed.date ? 'active' : ''}`}
+                onClick={() => commit({
+                  year: day.date.getFullYear(),
+                  month: day.date.getMonth() + 1,
+                  day: day.date.getDate()
+                })}>
+                {day.date.getDate()}
+              </button>
+            ))}
+          </div>
+          <div className="dt-time">
+            <label>
+              <span>时</span>
+              <input
+                value={String(parsed.hour).padStart(2, '0')}
+                inputMode="numeric"
+                maxLength={2}
+                onChange={e => commit({ hour: clampInt(e.target.value, 0, 23) })} />
+            </label>
+            <label>
+              <span>分</span>
+              <input
+                value={String(parsed.minute).padStart(2, '0')}
+                inputMode="numeric"
+                maxLength={2}
+                onChange={e => commit({ minute: clampInt(e.target.value, 0, 59) })} />
+            </label>
+            <button type="button" className="dt-now" onClick={() => onChange(U.toDateTimeLocalValue(new Date()))}>现在</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function parseDateTimeValue(value) {
+  const match = String(value || '').match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/);
+  const now = new Date();
+  const year = match ? Number(match[1]) : now.getFullYear();
+  const month = match ? Number(match[2]) : now.getMonth() + 1;
+  const day = match ? Number(match[3]) : now.getDate();
+  const hour = match ? Number(match[4]) : 0;
+  const minute = match ? Number(match[5]) : 0;
+  return { year, month, day, hour, minute, date: `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}` };
+}
+
+function formatDateTimeValue(value) {
+  return `${value.year}-${String(value.month).padStart(2, '0')}-${String(value.day).padStart(2, '0')}T${String(value.hour).padStart(2, '0')}:${String(value.minute).padStart(2, '0')}`;
+}
+
+function displayDateTime(value) {
+  return String(value || '').replace('T', ' ');
+}
+
+function monthCells(monthDate) {
+  const first = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1);
+  const start = new Date(first);
+  const offset = (first.getDay() + 6) % 7;
+  start.setDate(first.getDate() - offset);
+  return Array.from({ length: 42 }, (_, i) => {
+    const date = new Date(start);
+    date.setDate(start.getDate() + i);
+    const value = U.localDateStr(date);
+    return {
+      date,
+      value,
+      key: value,
+      inMonth: date.getMonth() === monthDate.getMonth()
+    };
+  });
+}
+
+function clampInt(value, min, max) {
+  const digits = String(value || '').replace(/\D/g, '');
+  const n = Number(digits);
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, n));
 }
 
 // ───────────────────────────────────────────────────────────────

--- a/src/client/dashboard/styles.css
+++ b/src/client/dashboard/styles.css
@@ -325,6 +325,206 @@ button, input, select { font-family: inherit; color: inherit; }
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
 }
 
+.time-range {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 2px 6px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.time-range.active {
+  background: oklch(0.97 0.02 265);
+  border-color: oklch(0.85 0.04 265);
+}
+
+.time-sep {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.dt-field {
+  position: relative;
+  display: inline-flex;
+}
+
+.time-trigger {
+  width: 158px;
+  height: 24px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.time-trigger:hover { background: var(--surface-2); }
+.time-trigger:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--c-indigo), transparent 70%);
+}
+
+.time-icon {
+  width: 13px;
+  height: 13px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.dt-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 40;
+  width: 252px;
+  padding: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 14px 36px -16px rgb(0 0 0 / 0.22), 0 0 0 1px color-mix(in oklab, var(--border), transparent 20%);
+}
+
+.dt-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.dt-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.dt-nav {
+  width: 24px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.dt-nav:hover {
+  background: var(--surface-2);
+  border-color: var(--border-2);
+}
+
+.dt-week,
+.dt-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.dt-week {
+  margin-bottom: 4px;
+}
+
+.dt-week span {
+  height: 20px;
+  display: grid;
+  place-items: center;
+  font-size: 10.5px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.dt-day {
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-2);
+  font-size: 12px;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.dt-day:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.dt-day.muted {
+  color: var(--subtle);
+}
+
+.dt-day.active {
+  background: var(--text);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+.dt-time {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-2);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dt-time label {
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 7px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface-2);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.dt-time input {
+  width: 24px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.dt-time input:focus {
+  outline: 0;
+}
+
+.dt-now {
+  margin-left: auto;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--c-indigo);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.dt-now:hover {
+  background: oklch(0.97 0.02 265);
+  border-color: oklch(0.85 0.04 265);
+}
+
 .pill {
   height: 28px;
   padding: 0 10px 0 8px;

--- a/src/client/shared/utils.js
+++ b/src/client/shared/utils.js
@@ -118,6 +118,37 @@ function daysAgo(n) {
   return localDateStr(d);
 }
 
+function toDateTimeLocalValue(date) {
+  return [
+    localDateStr(date),
+    [
+      String(date.getHours()).padStart(2, '0'),
+      String(date.getMinutes()).padStart(2, '0')
+    ].join(':')
+  ].join('T');
+}
+
+function startOfDayLocal(dateStr) {
+  const d = parseLocalDate(dateStr);
+  d.setHours(0, 0, 0, 0);
+  return toDateTimeLocalValue(d);
+}
+
+function endOfDayLocal(dateStr) {
+  const d = parseLocalDate(dateStr);
+  d.setHours(23, 59, 0, 0);
+  return toDateTimeLocalValue(d);
+}
+
+function timestampMs(value) {
+  if (!value) return null;
+  const text = String(value);
+  const normalized = text.includes('T') ? text : text.replace(' ', 'T');
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalized);
+  const ms = new Date(hasZone ? normalized : normalized).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
 function addDays(dateStr, days) {
   const d = parseLocalDate(dateStr);
   d.setDate(d.getDate() + days);
@@ -141,6 +172,20 @@ function filterDaily(rows, f) {
     (f.devices.size === 0 || f.devices.has(r.device)) &&
     (f.models.size  === 0 || f.models.has(r.model))
   );
+}
+
+function filterTime(rows, f) {
+  const startMs = timestampMs(f.startDateTime || startOfDayLocal(f.startDate));
+  const endMs = timestampMs(f.endDateTime || endOfDayLocal(f.endDate));
+  return rows.filter(r => {
+    const ms = timestampMs(r.eventTime);
+    return ms != null &&
+      (startMs == null || ms >= startMs) &&
+      (endMs == null || ms <= endMs) &&
+      (f.sources.size === 0 || f.sources.has(r.source)) &&
+      (f.devices.size === 0 || f.devices.has(r.device)) &&
+      (f.models.size  === 0 || f.models.has(r.model));
+  });
 }
 
 // Aggregate totals across rows
@@ -217,7 +262,7 @@ export const U = {
   PALETTE, PALETTE_FALLBACK, getSourceColor,
   fmt, fmtUS, fmtUS4,
   compact, compactCN, pct, deltaPct, formatTs,
-  localDateStr, daysAgo, addDays, rangeDates,
-  filterDaily, aggregateTotals, groupByDate, uniqueValues,
+  localDateStr, toDateTimeLocalValue, startOfDayLocal, endOfDayLocal, daysAgo, addDays, rangeDates,
+  filterDaily, filterTime, aggregateTotals, groupByDate, uniqueValues,
   downloadCSV, projectLabel, alpha
 };

--- a/src/collect.mjs
+++ b/src/collect.mjs
@@ -1,6 +1,6 @@
 import { hostname } from 'node:os';
 import { resolve } from 'node:path';
-import { openDb, recordRun, upsertDaily, upsertSession } from './db.mjs';
+import { deleteTimeUsageForSource, openDb, recordRun, upsertDaily, upsertSession, upsertTimeUsage } from './db.mjs';
 import { loadPricing } from './pricing.mjs';
 
 const COLLECTORS = [
@@ -19,6 +19,7 @@ const exportPayload = {
   device,
   collectedAt: new Date().toISOString(),
   daily: [],
+  time: [],
   sessions: [],
   runs: []
 };
@@ -41,10 +42,11 @@ async function collectLocal() {
   for (const { module, label } of COLLECTORS) {
     let graphJson;
     let modelsJson;
+    let eventsJson;
 
     try {
       const { collect } = await import(module);
-      ({ graphJson, modelsJson } = await collect(pricingData));
+      ({ graphJson, modelsJson, eventsJson } = await collect(pricingData));
     } catch (error) {
       const run = {
         device,
@@ -69,20 +71,75 @@ async function collectLocal() {
     runInTransaction(db, () => sessionRows.forEach((row) => upsertSession(db, row)));
     exportPayload.sessions.push(...sessionRows);
 
+    const timeRows = normalizeTimeRows(eventsJson, device);
+    runInTransaction(db, () => {
+      deleteTimeUsageForSource(db, device, label);
+      timeRows.forEach((row) => upsertTimeUsage(db, row));
+    });
+    exportPayload.time.push(...timeRows);
+
     const run = {
       device,
       source: label,
       status: dailyRows.length || sessionRows.length ? 'ok' : 'empty',
-      message: `daily=${dailyRows.length}, workspace_model=${sessionRows.length}`,
+      message: `daily=${dailyRows.length}, time=${timeRows.length}, workspace_model=${sessionRows.length}`,
       collectedAt: exportPayload.collectedAt,
       command: `js-collector:${module}`
     };
     recordRun(db, run);
     exportPayload.runs.push(run);
-    console.log(`[${label}] daily=${dailyRows.length}, workspace_model=${sessionRows.length}`);
+    console.log(`[${label}] daily=${dailyRows.length}, time=${timeRows.length}, workspace_model=${sessionRows.length}`);
   }
 
   if (anyError) process.exitCode = 1;
+}
+
+function normalizeTimeRows(json, deviceName) {
+  const events = Array.isArray(json?.events) ? json.events : [];
+  return events.map((entry, index) => {
+    const tokens = normalizeTokens(entry.tokens);
+    const eventTime = normalizeEventTime(entry.eventTime || entry.timestamp);
+    const usageDate = entry.usageDate || entry.date || eventTime.slice(0, 10);
+    const source = sourceLabel(entry.client);
+    const model = entry.modelId || entry.model || entry.model_id || 'unknown';
+    return {
+      device: deviceName,
+      source,
+      eventKey: entry.eventKey || [
+        entry.client || 'unknown',
+        eventTime,
+        entry.sessionId || entry.workspaceKey || '',
+        model,
+        tokenTotal(tokens),
+        index
+      ].join(':'),
+      eventTime,
+      usageDate,
+      model,
+      projectPath: entry.workspaceLabel || entry.projectPath || entry.workspaceKey || null,
+      sessionId: entry.sessionId || null,
+      inputTokens: tokens.input,
+      outputTokens: tokens.output,
+      cacheCreationTokens: tokens.cacheWrite,
+      cacheReadTokens: tokens.cacheRead,
+      reasoningOutputTokens: tokens.reasoning,
+      totalTokens: tokenTotal(tokens),
+      costUSD: entry.cost || 0
+    };
+  }).filter(row => row.eventTime && row.usageDate && row.totalTokens > 0);
+}
+
+function normalizeEventTime(value) {
+  if (!value) return '';
+  if (typeof value === 'number') {
+    const ms = value < 10_000_000_000 ? value * 1000 : value;
+    return new Date(ms).toISOString();
+  }
+  const text = String(value).trim();
+  if (!text) return '';
+  const normalized = text.includes('T') ? text : text.replace(' ', 'T');
+  const date = new Date(/(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalized) ? normalized : `${normalized}Z`);
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString();
 }
 
 function runInTransaction(database, work) {

--- a/src/collectors/claude-code.mjs
+++ b/src/collectors/claude-code.mjs
@@ -16,6 +16,8 @@ import { localDateFromTimestamp, normalizeModelForGrouping } from './utils.mjs';
 
 export const CLIENT_KEY = 'claude';
 export const SOURCE_LABEL = 'Claude Code';
+const EVENT_HISTORY_DAYS = Number(process.env.TIME_USAGE_HISTORY_DAYS || 90);
+const EVENT_CUTOFF_MS = Date.now() - EVENT_HISTORY_DAYS * 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Path resolution
@@ -251,6 +253,7 @@ export async function collect(pricingData = null) {
   const dailyMap = new Map();
   // workspaceModelKey ("workspaceDir::model") -> aggregated token counts
   const wmMap = new Map();
+  const events = [];
 
   for (const root of await getScanRoots()) {
     const filePaths = await collectJsonlFiles(root.path);
@@ -261,7 +264,7 @@ export async function collect(pricingData = null) {
 
       for (const record of records) {
         const tokens = extractTokens(record.usage);
-        aggregateRecord({ ...record, tokens, workspaceKey, workspaceLabel }, dailyMap, wmMap, pricingData);
+        aggregateRecord({ ...record, tokens, workspaceKey, workspaceLabel, filePath }, dailyMap, wmMap, pricingData, events);
       }
     }
   }
@@ -313,7 +316,7 @@ export async function collect(pricingData = null) {
 
   const modelsJson = { entries };
 
-  return { graphJson, modelsJson };
+  return { graphJson, modelsJson, eventsJson: { events } };
 }
 
 function workspaceKeyFromPath(root, filePath) {
@@ -323,12 +326,27 @@ function workspaceKeyFromPath(root, filePath) {
   return `transcripts:${firstSegment || filePath}`;
 }
 
-function aggregateRecord(record, dailyMap, wmMap, pricingData) {
+function aggregateRecord(record, dailyMap, wmMap, pricingData, events) {
   const date = localDateFromTimestamp(record.timestamp);
   const model = normalizeModelForGrouping(record.model);
   const tokens = record.tokens || extractTokens(record.usage);
   const calculatedCost = calculateCost(model, tokens, pricingData);
   const costUSD = calculatedCost > 0 ? calculatedCost : record.costUSD;
+
+  if (keepTimeEvent(record.timestamp)) {
+    events.push({
+      client: CLIENT_KEY,
+      eventKey: `${record.filePath || record.workspaceKey}:${record.timestamp || ''}:${model}:${JSON.stringify(tokens)}`,
+      eventTime: record.timestamp,
+      usageDate: date,
+      sessionId: record.filePath,
+      workspaceKey: record.workspaceKey,
+      workspaceLabel: record.workspaceLabel,
+      model,
+      tokens,
+      cost: costUSD
+    });
+  }
 
   // --- daily ---
   const dk = `${date}::${model}`;
@@ -353,4 +371,9 @@ function aggregateRecord(record, dailyMap, wmMap, pricingData) {
   const wmAgg = wmMap.get(wmk);
   addInto(wmAgg, tokens);
   wmAgg.cost += costUSD;
+}
+
+function keepTimeEvent(timestamp) {
+  const ms = Date.parse(timestamp || '');
+  return Number.isFinite(ms) && ms >= EVENT_CUTOFF_MS;
 }

--- a/src/collectors/codex.mjs
+++ b/src/collectors/codex.mjs
@@ -45,6 +45,8 @@ async function collectJsonlFiles(dir) {
 
 export const CLIENT_KEY = 'codex';
 export const SOURCE_LABEL = 'Codex CLI';
+const EVENT_HISTORY_DAYS = Number(process.env.TIME_USAGE_HISTORY_DAYS || 90);
+const EVENT_CUTOFF_MS = Date.now() - EVENT_HISTORY_DAYS * 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Path resolution
@@ -305,20 +307,35 @@ export async function collect(pricingData = null) {
   const nestedPaths = await Promise.all(roots.map((root) => collectJsonlFiles(root)));
   const filePaths = [...new Set(nestedPaths.flat())];
 
-  const dailyMap = new Map();   // "date::model" → aggregated
-  const wmMap    = new Map();   // "workspace::model" → aggregated
+  const dailyMap = new Map();   // "date::model" -> aggregated
+  const wmMap    = new Map();   // "workspace::model" -> aggregated
+  const events   = [];
   const seenEventKeys = new Set();
 
   for (const filePath of filePaths) {
     const sessionId = basename(filePath).replace(/\.jsonl$/, '');
-    const events    = await parseSessionFile(filePath, sessionId);
+    const parsedEvents = await parseSessionFile(filePath, sessionId);
 
-    for (const { timestamp, date, model, workspace, tokens } of events) {
+    for (const { timestamp, date, model, workspace, tokens } of parsedEvents) {
       const eventKey = codexEventDedupKey({ timestamp, model, tokens });
       if (eventKey && seenEventKeys.has(eventKey)) continue;
       if (eventKey) seenEventKeys.add(eventKey);
 
       const workspaceKey = workspace || sessionId;
+      if (keepTimeEvent(timestamp)) {
+        events.push({
+          client: CLIENT_KEY,
+          eventKey: eventKey || `${filePath}::${timestamp}`,
+          eventTime: timestamp,
+          usageDate: date,
+          sessionId,
+          workspaceKey,
+          workspaceLabel: decodeWorkspace(workspaceKey),
+          model,
+          tokens,
+          cost: calculateCost(model, tokens, pricingData)
+        });
+      }
 
       // Daily
       const dk = `${date}::${model}`;
@@ -340,7 +357,7 @@ export async function collect(pricingData = null) {
     }
   }
 
-  return buildOutput(dailyMap, wmMap, pricingData);
+  return { ...buildOutput(dailyMap, wmMap, pricingData), eventsJson: { events } };
 }
 
 function codexEventDedupKey({ timestamp, model, tokens }) {
@@ -354,6 +371,11 @@ function codexEventDedupKey({ timestamp, model, tokens }) {
     tokens.cacheWrite,
     tokens.reasoning
   ].join('::');
+}
+
+function keepTimeEvent(timestamp) {
+  const ms = Date.parse(timestamp || '');
+  return Number.isFinite(ms) && ms >= EVENT_CUTOFF_MS;
 }
 
 /**
@@ -371,8 +393,9 @@ function decodeWorkspace(raw) {
 function buildOutput(dailyMap, wmMap, pricingData) {
   const byDate = new Map();
   for (const row of dailyMap.values()) {
-    if (!byDate.has(row.date)) byDate.set(row.date, []);
-    byDate.get(row.date).push(row);
+    const date = typeof row.date === 'string' && row.date ? row.date : 'unknown';
+    if (!byDate.has(date)) byDate.set(date, []);
+    byDate.get(date).push(row);
   }
 
   const contributions = [...byDate.entries()]

--- a/src/collectors/hermes.mjs
+++ b/src/collectors/hermes.mjs
@@ -17,6 +17,8 @@ import { canonicalProvider, inferProviderFromModel, localDateFromTimestamp, norm
 
 export const CLIENT_KEY = 'hermes';
 export const SOURCE_LABEL = 'Hermes Agent';
+const EVENT_HISTORY_DAYS = Number(process.env.TIME_USAGE_HISTORY_DAYS || 90);
+const EVENT_CUTOFF_MS = Date.now() - EVENT_HISTORY_DAYS * 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Path resolution
@@ -120,6 +122,7 @@ export async function collect(pricingData = null) {
 
   const dailyMap = new Map();   // "date::model" -> aggregated
   const wmMap    = new Map();   // sessionId -> session-level record
+  const events   = [];
 
   for (const row of rows) {
     const date     = tsToDate(row.started_at);
@@ -136,6 +139,20 @@ export async function collect(pricingData = null) {
     const calculatedCost = calculateCost(model, tokens, pricingData, provider);
     const cost = originalCost > 0 ? originalCost : calculatedCost;
     const sessId   = String(row.id || 'unknown');
+    if (keepTimeEvent(row.started_at)) {
+      events.push({
+        client: CLIENT_KEY,
+        eventKey: sessId,
+        eventTime: row.started_at,
+        usageDate: date,
+        sessionId: sessId,
+        workspaceKey: sessId,
+        workspaceLabel: sessId,
+        model,
+        tokens,
+        cost
+      });
+    }
 
     // Daily aggregation
     const dk = `${date}::${model}`;
@@ -155,7 +172,13 @@ export async function collect(pricingData = null) {
     });
   }
 
-  return buildOutput(dailyMap, wmMap);
+  return { ...buildOutput(dailyMap, wmMap), eventsJson: { events } };
+}
+
+function keepTimeEvent(timestamp) {
+  const n = Number(timestamp || 0);
+  const ms = n < 10_000_000_000 ? n * 1000 : n;
+  return Number.isFinite(ms) && ms >= EVENT_CUTOFF_MS;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/collectors/opencode.mjs
+++ b/src/collectors/opencode.mjs
@@ -17,6 +17,8 @@ import { canonicalProvider, inferProviderFromModel, localDateFromTimestamp, norm
 
 export const CLIENT_KEY = 'opencode';
 export const SOURCE_LABEL = 'OpenCode';
+const EVENT_HISTORY_DAYS = Number(process.env.TIME_USAGE_HISTORY_DAYS || 90);
+const EVENT_CUTOFF_MS = Date.now() - EVENT_HISTORY_DAYS * 24 * 60 * 60 * 1000;
 
 function opencodeDataDir() {
   return configuredPath(
@@ -153,6 +155,7 @@ function parseMessageObject(msg, fallbackId, fallbackSessionId, fallbackWorkspac
     sessionId: msg.sessionID || fallbackSessionId || 'unknown',
     dedupKey: msg.id || fallbackId || null,
     fingerprint: fingerprintFor(msg, tokens, model, provider),
+    eventTime: timestamp,
     date: localDateFromTimestamp(timestamp, 'unknown'),
     model,
     provider,
@@ -259,6 +262,7 @@ async function parseLegacyJsonFile(filePath) {
 export async function collect(pricingData = null) {
   const dailyMap = new Map();
   const wmMap = new Map();
+  const events = [];
   const seen = new Set();
 
   const addMessage = (message) => {
@@ -269,6 +273,20 @@ export async function collect(pricingData = null) {
 
     const calculatedCost = calculateCost(message.model, message.tokens, pricingData, message.provider);
     const cost = message.cost > 0 ? message.cost : calculatedCost;
+    if (keepTimeEvent(message.eventTime)) {
+      events.push({
+        client: CLIENT_KEY,
+        eventKey: message.dedupKey || message.fingerprint,
+        eventTime: message.eventTime,
+        usageDate: message.date,
+        sessionId: message.sessionId,
+        workspaceKey: message.workspace || message.sessionId || 'unknown',
+        workspaceLabel: message.workspaceLabel || message.workspace || message.sessionId || 'unknown',
+        model: message.model,
+        tokens: message.tokens,
+        cost
+      });
+    }
 
     const dk = `${message.date}::${message.model}`;
     if (!dailyMap.has(dk)) {
@@ -303,7 +321,13 @@ export async function collect(pricingData = null) {
     addMessage(await parseLegacyJsonFile(jsonPath));
   }
 
-  return buildOutput(dailyMap, wmMap);
+  return { ...buildOutput(dailyMap, wmMap), eventsJson: { events } };
+}
+
+function keepTimeEvent(timestamp) {
+  const n = Number(timestamp || 0);
+  const ms = n < 10_000_000_000 ? n * 1000 : n;
+  return Number.isFinite(ms) && ms >= EVENT_CUTOFF_MS;
 }
 
 function buildOutput(dailyMap, wmMap) {

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -62,9 +62,32 @@ function initSchema(db) {
       PRIMARY KEY (device, source, session_id)
     );
 
+    CREATE TABLE IF NOT EXISTS time_usage (
+      device TEXT NOT NULL,
+      source TEXT NOT NULL,
+      event_key TEXT NOT NULL,
+      event_time TEXT NOT NULL,
+      usage_date TEXT NOT NULL,
+      model TEXT NOT NULL DEFAULT '',
+      project_path TEXT,
+      session_id TEXT,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+      cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+      reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+      total_tokens INTEGER NOT NULL DEFAULT 0,
+      cost_usd REAL NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (device, source, event_key)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_daily_usage_date ON daily_usage(usage_date);
     CREATE INDEX IF NOT EXISTS idx_daily_usage_source ON daily_usage(source);
     CREATE INDEX IF NOT EXISTS idx_session_usage_total ON session_usage(total_tokens DESC);
+    CREATE INDEX IF NOT EXISTS idx_time_usage_time ON time_usage(event_time);
+    CREATE INDEX IF NOT EXISTS idx_time_usage_date_source ON time_usage(usage_date, source);
   `);
 
   ensureColumn(db, 'daily_usage', 'pricing_locked_at', 'TEXT');
@@ -74,6 +97,55 @@ function initSchema(db) {
     WHERE pricing_locked_at IS NULL
       AND usage_date < date('now', 'localtime')
   `);
+}
+
+export function upsertTimeUsage(db, row) {
+  db.prepare(`
+    INSERT INTO time_usage (
+      device, source, event_key, event_time, usage_date, model, project_path, session_id,
+      input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+      cached_input_tokens, reasoning_output_tokens, total_tokens, cost_usd, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    ON CONFLICT(device, source, event_key) DO UPDATE SET
+      event_time = excluded.event_time,
+      usage_date = excluded.usage_date,
+      model = excluded.model,
+      project_path = excluded.project_path,
+      session_id = excluded.session_id,
+      input_tokens = excluded.input_tokens,
+      output_tokens = excluded.output_tokens,
+      cache_creation_tokens = excluded.cache_creation_tokens,
+      cache_read_tokens = excluded.cache_read_tokens,
+      cached_input_tokens = excluded.cached_input_tokens,
+      reasoning_output_tokens = excluded.reasoning_output_tokens,
+      total_tokens = excluded.total_tokens,
+      cost_usd = excluded.cost_usd,
+      updated_at = datetime('now')
+  `).run(
+    row.device,
+    row.source,
+    row.eventKey,
+    row.eventTime,
+    row.usageDate,
+    row.model || '',
+    row.projectPath || null,
+    row.sessionId || null,
+    row.inputTokens || 0,
+    row.outputTokens || 0,
+    row.cacheCreationTokens || 0,
+    row.cacheReadTokens || 0,
+    row.cachedInputTokens || 0,
+    row.reasoningOutputTokens || 0,
+    row.totalTokens || 0,
+    row.costUSD || 0
+  );
+}
+
+export function deleteTimeUsageForSource(db, device, source) {
+  db.prepare(`
+    DELETE FROM time_usage
+    WHERE device = ? AND source = ?
+  `).run(device, source);
 }
 
 export function upsertDaily(db, row) {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
 import { extname, join, resolve } from 'node:path';
 import { URL } from 'node:url';
-import { openDb, recordRun, upsertDaily, upsertSession } from './db.mjs';
+import { openDb, recordRun, upsertDaily, upsertSession, upsertTimeUsage } from './db.mjs';
 import { loadCollectorConfig } from './collector-config.mjs';
 
 const port = Number(process.env.PORT || 4173);
@@ -112,6 +112,24 @@ function handleApi(req, url, res) {
       FROM collection_runs
       ORDER BY id DESC
     `);
+    const rawTime = all(`
+      SELECT rowid AS id, device, source,
+        event_time AS eventTime,
+        usage_date AS usageDate,
+        model,
+        project_path AS projectPath,
+        session_id AS sessionId,
+        input_tokens AS inputTokens,
+        output_tokens AS outputTokens,
+        cache_creation_tokens AS cacheCreationTokens,
+        cache_read_tokens AS cacheReadTokens,
+        cached_input_tokens AS cachedInputTokens,
+        reasoning_output_tokens AS reasoningOutputTokens,
+        total_tokens AS totalTokens,
+        cost_usd AS costUSD
+      FROM time_usage
+      ORDER BY event_time DESC
+    `);
 
     // Normalize sessions
     const sessions = rawSessions.map(s => ({
@@ -158,6 +176,7 @@ function handleApi(req, url, res) {
         ...d,
         projectPath: projMap.get(`${d.device}::${d.source}`)?.project || null
       })),
+      time: rawTime,
       sessions,
       // Normalize runs: strip newlines from messages, shorten device names
       runs: rawRuns.map(r => ({
@@ -314,12 +333,14 @@ async function handleIngest(req, res) {
   try {
     const payload = await readJson(req);
     const dailyRows = Array.isArray(payload.daily) ? payload.daily : [];
+    const timeRows = Array.isArray(payload.time) ? payload.time : [];
     const sessionRows = Array.isArray(payload.sessions) ? payload.sessions : [];
     const runRows = Array.isArray(payload.runs) ? payload.runs : [];
 
     db.exec('BEGIN');
     try {
       dailyRows.forEach((row) => upsertDaily(db, row));
+      timeRows.forEach((row) => upsertTimeUsage(db, row));
       sessionRows.forEach((row) => upsertSession(db, row));
       runRows.forEach((row) => recordRun(db, row));
       db.exec('COMMIT');
@@ -328,7 +349,7 @@ async function handleIngest(req, res) {
       throw error;
     }
 
-    sendJson(res, { ok: true, daily: dailyRows.length, sessions: sessionRows.length, runs: runRows.length });
+    sendJson(res, { ok: true, daily: dailyRows.length, time: timeRows.length, sessions: sessionRows.length, runs: runRows.length });
   } catch (error) {
     sendJson(res, { error: error.message }, 400);
   }


### PR DESCRIPTION
## What changed

- Added event-level `time_usage` storage so dashboard stats can be filtered by an exact date-time range, not only whole-day ranges.
- Extended local collectors to emit recent event-level usage for Codex CLI, Claude Code, Hermes Agent, and OpenCode.
- Added a custom in-app date-time picker that matches the dashboard visual system instead of relying on the browser-native `datetime-local` popover.
- Fixed stacked trend bar rounding so the actual top segment for each day gets rounded corners.

## Why

The previous filter UI could only filter by date buckets. Native date-time controls also produced inconsistent browser styling, and stacked bar rounding depended on source order rather than the visible top segment.

## Impact

Users can select precise time ranges and get matching KPI, chart, source, model, and table statistics. The filter UI now stays visually consistent with the rest of Token Studio.

## Validation

- `npm run build`
- `npm run collect`
- Verified local API and frontend returned HTTP 200.
- Verified the custom picker renders with no native `datetime-local` inputs in the DOM.
