### PR TITLE
fix: heatmap tooltip placement; feat: dark theme + plainer collect icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <script>
+      // Runs before first paint so a dark session never flashes the light
+      // theme. Mirrors resolveTheme() in src/client/shared/theme.js.
+      (function () {
+        var stored = null;
+        try { stored = localStorage.getItem('ts-theme'); } catch (e) {}
+        var theme = stored === 'light' || stored === 'dark'
+          ? stored
+          : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.dataset.theme = theme;
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/client/dashboard/components-charts.jsx
+++ b/src/client/dashboard/components-charts.jsx
@@ -2,7 +2,7 @@
    Charts — Trend, Donut, TopModels, Heatmap, Gauge, Stat
    ============================================================= */
 
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as echarts from 'echarts';
 import { U } from '../shared/utils.js';
 import { EChart } from '../shared/echart.jsx';
@@ -441,7 +441,10 @@ function TopModels({ rows, onDrillModel }) {
 // ───────────────────────────────────────────────────────────────
 function Heatmap({ rows, dates, loading = false, error = null }) {
   const [activeCell, setActiveCell] = useState(null);
+  const [tipBox, setTipBox] = useState(null);
   const gridRef = useRef(null);
+  const scrollRef = useRef(null);
+  const tipRef = useRef(null);
 
   const byCell = new Map();
   const byDate = new Map();
@@ -513,28 +516,66 @@ function Heatmap({ rows, dates, loading = false, error = null }) {
 
   const HOURS_LABELS = ['0', '', '', '', '4', '', '', '', '8', '', '', '', '12', '', '', '', '16', '', '', '', '20', '', '', ''];
 
+  // Gap between the cell and the tooltip body, wide enough for the arrow.
+  const TOOLTIP_GAP = 9;
+  // Keep the arrow off the rounded corners so it still reads as a pointer.
+  const ARROW_INSET = 14;
+
   const showTooltip = (event, date, hour, cell) => {
     const grid = gridRef.current;
     if (!grid) return;
 
     const gridRect = grid.getBoundingClientRect();
     const cellRect = event.currentTarget.getBoundingClientRect();
-    const dayTotal = byDate.get(date) || 0;
-    // Clamp inside the grid: an overflowing tooltip expands the scrollable
-    // area of .heatmap-scroll and pops a horizontal scrollbar on edge cells.
-    const half = 92;
-    const anchor = cellRect.left - gridRect.left + cellRect.width / 2;
-    const left = Math.min(Math.max(anchor, half), Math.max(half, gridRect.width - half));
     setActiveCell({
       date,
       hour,
       ...cell,
-      dayTotal,
-      left,
-      arrowShift: anchor - left,
-      top: cellRect.top - gridRect.top
+      dayTotal: byDate.get(date) || 0,
+      gridWidth: gridRect.width,
+      anchor: cellRect.left - gridRect.left + cellRect.width / 2,
+      cellTop: cellRect.top - gridRect.top,
+      cellBottom: cellRect.bottom - gridRect.top
     });
+    setTipBox(null);
   };
+
+  // The tooltip's own size decides where it can go, so place it only once it is
+  // in the DOM. Runs before paint, so the unmeasured pass is never visible.
+  useLayoutEffect(() => {
+    const tip = tipRef.current;
+    const grid = gridRef.current;
+    const scroll = scrollRef.current;
+    if (!activeCell || !tip || !grid || !scroll) return;
+
+    const gridRect = grid.getBoundingClientRect();
+    const scrollRect = scroll.getBoundingClientRect();
+    const {width, height} = tip.getBoundingClientRect();
+
+    // Clamp inside the grid: an overflowing tooltip expands the scrollable
+    // area of .heatmap-scroll and pops a horizontal scrollbar on edge cells.
+    const half = width / 2;
+    const left = Math.min(
+      Math.max(activeCell.anchor, half),
+      Math.max(half, gridRect.width - half)
+    );
+    // The arrow tracks the cell, but it has to stay on the tooltip body —
+    // off the edge the rotated square loses its cover and reads as a diamond.
+    const maxShift = Math.max(0, half - ARROW_INSET);
+    const arrowShift = Math.min(Math.max(activeCell.anchor - left, -maxShift), maxShift);
+
+    // .heatmap-scroll scrolls on X, which forces overflow-y to clip as well, so
+    // the top rows have no room above them. Flip under the cell instead.
+    const roomAbove = gridRect.top - scrollRect.top + activeCell.cellTop;
+    const below = roomAbove < height + TOOLTIP_GAP;
+
+    setTipBox({
+      left,
+      arrowShift,
+      below,
+      top: below ? activeCell.cellBottom : activeCell.cellTop
+    });
+  }, [activeCell]);
 
   return (
     <div className="panel">
@@ -561,7 +602,7 @@ function Heatmap({ rows, dates, loading = false, error = null }) {
       </div>
       <div className="heatmap-layout">
         <div className="heatmap-main">
-          <div className="heatmap-scroll">
+          <div className="heatmap-scroll" ref={scrollRef}>
             <div
               ref={gridRef}
               className="heatmap-grid"
@@ -619,9 +660,17 @@ function Heatmap({ rows, dates, loading = false, error = null }) {
 
               {activeCell && (
                 <div
-                  className="heat-tooltip"
+                  ref={tipRef}
+                  className={`heat-tooltip${tipBox?.below ? ' heat-tooltip-below' : ''}`}
                   role="tooltip"
-                  style={{left: activeCell.left, top: activeCell.top, '--arrow-shift': `${activeCell.arrowShift || 0}px`}}>
+                  style={{
+                    // Before measuring, park it mid-grid so it cannot widen the
+                    // scroll area, and keep it hidden until it is placed.
+                    left: tipBox ? tipBox.left : activeCell.gridWidth / 2,
+                    top: tipBox ? tipBox.top : activeCell.cellTop,
+                    visibility: tipBox ? 'visible' : 'hidden',
+                    '--arrow-shift': `${tipBox?.arrowShift || 0}px`
+                  }}>
                   <strong>{activeCell.date} · {String(activeCell.hour).padStart(2, '0')}:00</strong>
                   {activeCell.tokens > 0 ? (
                     <>

--- a/src/client/dashboard/components-charts.jsx
+++ b/src/client/dashboard/components-charts.jsx
@@ -8,6 +8,7 @@ import { U } from '../shared/utils.js';
 import { EChart } from '../shared/echart.jsx';
 import { Delta, Spark } from './components-top.jsx';
 import { sourceIcon, sourceIconScale } from './source-icons.js';
+import { chartPalette, useTheme } from '../shared/theme.js';
 
 // ───────────────────────────────────────────────────────────────
 // Trend chart — switchable bar/line/stacked + optional comparison
@@ -19,6 +20,10 @@ const TREND_MODES = [
 ];
 
 function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onModeChange, totals, prevTotals, onExport, density }) {
+  // ECharts paints to canvas, so chart chrome takes its colours from the
+  // palette rather than CSS variables.
+  const pal = chartPalette(useTheme().theme);
+
   // build series
   const byKey = useMemo(() => {
     const m = new Map();
@@ -120,8 +125,8 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
       type: 'line',
       smooth: 0.3,
       symbol: 'none',
-      lineStyle: { width: 1.2, color: 'oklch(0.72 0.005 80)', type: 'dashed', opacity: 0.55 },
-      itemStyle: { color: 'oklch(0.72 0.005 80)' },
+      lineStyle: { width: 1.2, color: pal.markLine, type: 'dashed', opacity: 0.55 },
+      itemStyle: { color: pal.markLine },
       ...stableLineState(1.2),
       data: dates.map((_, i) => compareSeries[i] || 0),
       z: 3
@@ -135,8 +140,8 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
       type: 'line',
       smooth: 0.5,
       symbol: 'none',
-      lineStyle: { width: 1.6, color: 'oklch(0.45 0.04 265)', type: [4, 4] },
-      itemStyle: { color: 'oklch(0.45 0.04 265)' },
+      lineStyle: { width: 1.6, color: pal.markLineCompare, type: [4, 4] },
+      itemStyle: { color: pal.markLineCompare },
       ...stableLineState(1.6),
       data: rolling,
       z: 4
@@ -151,24 +156,24 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
       trigger: 'axis',
       axisPointer: {
         type: 'line',
-        lineStyle: { color: 'oklch(0.62 0.04 265 / 0.45)', width: 1, type: [3, 3] }
+        lineStyle: { color: pal.crossHair, width: 1, type: [3, 3] }
       },
-      backgroundColor: '#ffffff',
-      borderColor: 'oklch(0.92 0.004 80)',
+      backgroundColor: pal.tooltipBg,
+      borderColor: pal.tooltipBorder,
       borderWidth: 1,
       padding: [10, 12],
-      textStyle: { color: 'oklch(0.18 0.005 80)', fontSize: 12 },
-      extraCssText: 'box-shadow: 0 8px 24px rgba(15,23,42,0.10); border-radius: 10px;',
+      textStyle: { color: pal.tooltipText, fontSize: 12 },
+      extraCssText: 'box-shadow: var(--shadow-pop); border-radius: 10px;',
       formatter(params) {
         const date = params[0]?.axisValue || '';
         let total = 0;
         for (const p of params) if (sources.includes(p.seriesName)) total += p.value || 0;
-        let html = `<div style="font-weight:600;margin-bottom:6px;color:oklch(0.40 0.005 80);font-size:11.5px;letter-spacing:.04em">${date}</div>`;
-        html += `<div style="font-size:16px;font-weight:600;margin-bottom:8px">${U.compactCN(total)} <span style="font-size:11px;color:oklch(0.55 0.005 80);font-weight:500"> tokens</span></div>`;
+        let html = `<div style="font-weight:600;margin-bottom:6px;color:${pal.tooltipLabel};font-size:11.5px;letter-spacing:.04em">${date}</div>`;
+        html += `<div style="font-size:16px;font-weight:600;margin-bottom:8px">${U.compactCN(total)} <span style="font-size:11px;color:${pal.tooltipMuted};font-weight:500"> tokens</span></div>`;
         for (const p of params) {
           html += `<div style="display:flex;align-items:center;gap:8px;margin-top:3px;font-size:12px">
             <span style="width:8px;height:8px;border-radius:2px;background:${p.color};display:inline-block"></span>
-            <span style="color:oklch(0.45 0.005 80);flex:1">${p.seriesName}</span>
+            <span style="color:${pal.tooltipSeries};flex:1">${p.seriesName}</span>
             <span style="font-weight:600;margin-left:18px;font-variant-numeric:tabular-nums">${U.compactCN(p.value || 0)}</span>
           </div>`;
         }
@@ -181,10 +186,10 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
       type: 'category',
       data: dates,
       boundaryGap: mode !== 'line',
-      axisLine: { lineStyle: { color: 'oklch(0.92 0.004 80)' } },
+      axisLine: { lineStyle: { color: pal.axisLine } },
       axisTick: { show: false },
       axisLabel: {
-        color: 'oklch(0.55 0.005 80)',
+        color: pal.axisLabel,
         fontSize: 10.5,
         hideOverlap: true,
         formatter: v => v.slice(5)
@@ -193,11 +198,11 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
     yAxis: {
       type: 'value',
       axisLabel: {
-        color: 'oklch(0.62 0.004 80)',
+        color: pal.axisLabelDim,
         fontSize: 10.5,
         formatter: v => U.compact(v)
       },
-      splitLine: { lineStyle: { color: 'oklch(0.95 0.004 80)' } },
+      splitLine: { lineStyle: { color: pal.splitLine } },
       axisLine: { show: false },
       axisTick: { show: false }
     },
@@ -208,11 +213,11 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
         height: 18,
         bottom: 4,
         borderColor: 'transparent',
-        backgroundColor: 'oklch(0.97 0.004 80)',
-        fillerColor: 'oklch(0.92 0.02 265 / 0.5)',
-        handleStyle: { color: '#fff', borderColor: 'oklch(0.55 0.16 265)' },
+        backgroundColor: pal.zoomBg,
+        fillerColor: pal.zoomFiller,
+        handleStyle: { color: pal.zoomHandle, borderColor: pal.zoomHandleEdge },
         moveHandleSize: 4,
-        textStyle: { color: 'oklch(0.55 0.005 80)', fontSize: 10 }
+        textStyle: { color: pal.tooltipMuted, fontSize: 10 }
       }
     ] : [],
     series
@@ -253,6 +258,7 @@ function TrendChart({ rows, dates, sources, compareRows, compareDates, mode, onM
 // Donut chart — source share
 // ───────────────────────────────────────────────────────────────
 function SourceDonut({ rows, sources, total, onFocusSource, focused }) {
+  const pal = chartPalette(useTheme().theme);
   const data = sources.map(src => {
     let v = 0;
     for (const r of rows) if (r.source === src) v += r.totalTokens;
@@ -268,14 +274,14 @@ function SourceDonut({ rows, sources, total, onFocusSource, focused }) {
       appendToBody: true,
       confine: true,
       transitionDuration: 0,
-      backgroundColor: '#fff',
-      borderColor: 'oklch(0.92 0.004 80)',
+      backgroundColor: pal.tooltipBg,
+      borderColor: pal.tooltipBorder,
       borderWidth: 1,
-      textStyle: { color: 'oklch(0.18 0.005 80)', fontSize: 12 },
+      textStyle: { color: pal.tooltipText, fontSize: 12 },
       extraCssText: 'pointer-events:none;box-shadow:0 8px 24px rgb(0 0 0 / 0.08);border-radius:8px;',
       formatter: p => `<div style="font-weight:600;margin-bottom:4px">${p.name}</div>
         <div style="font-size:14px;font-weight:600">${U.compactCN(p.value)} tokens</div>
-        <div style="font-size:11px;color:oklch(0.55 0.005 80)">${(p.percent || 0).toFixed(1)}%</div>`
+        <div style="font-size:11px;color:${pal.tooltipMuted}">${(p.percent || 0).toFixed(1)}%</div>`
     },
     series: [{
       type: 'pie',
@@ -292,7 +298,7 @@ function SourceDonut({ rows, sources, total, onFocusSource, focused }) {
       label: { show: false },
       labelLine: { show: false },
       itemStyle: {
-        borderColor: '#fff',
+        borderColor: pal.sliceBorder,
         borderWidth: 2,
         shadowBlur: 12,
         shadowOffsetY: 3,
@@ -323,7 +329,7 @@ function SourceDonut({ rows, sources, total, onFocusSource, focused }) {
               color: d.color,
               borderRadius,
               opacity: 1,
-              borderColor: '#fff',
+              borderColor: pal.sliceBorder,
               borderWidth: 2,
               shadowBlur: 12,
               shadowOffsetY: 3,
@@ -769,7 +775,7 @@ function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitR
       <div className="gauge">
         <div className="gauge-wrap">
           <svg viewBox="0 0 180 100" width="180" height="100">
-            <path d="M 10 90 A 80 80 0 0 1 170 90" stroke="oklch(0.95 0.004 80)" strokeWidth="14" fill="none" strokeLinecap="round"/>
+            <path d="M 10 90 A 80 80 0 0 1 170 90" stroke="var(--gauge-track)" strokeWidth="14" fill="none" strokeLinecap="round"/>
             <path
               d="M 10 90 A 80 80 0 0 1 170 90"
               stroke="url(#hitGrad)"
@@ -779,8 +785,8 @@ function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitR
             />
             <defs>
               <linearGradient id="hitGrad" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stopColor="oklch(0.65 0.13 200)"/>
-                <stop offset="100%" stopColor="oklch(0.55 0.16 265)"/>
+                <stop offset="0%" stopColor="var(--c-teal)"/>
+                <stop offset="100%" stopColor="var(--c-indigo)"/>
               </linearGradient>
             </defs>
           </svg>
@@ -808,7 +814,7 @@ function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitR
         <div className="cache-trend-head">
           <span>每日命中率</span>
         </div>
-        <Spark values={hitRateSeries} color="oklch(0.65 0.11 200)" height={36}/>
+        <Spark values={hitRateSeries} color="var(--c-teal)" height={36}/>
       </div>
     </div>
   );

--- a/src/client/dashboard/components-top.jsx
+++ b/src/client/dashboard/components-top.jsx
@@ -4,6 +4,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { U } from '../shared/utils.js';
+import { ThemeToggle } from '../shared/ThemeToggle.jsx';
 import claudeIcon from './icons/claude.svg';
 import gptIcon from './icons/gpt.svg';
 import { sourceIcon, sourceIconScale } from './source-icons.js';
@@ -184,17 +185,11 @@ function Topbar({ lastSync, onRefresh, refreshing, onCollect, collecting, collec
           <span className="sync-dot"></span>
           <span>最后同步 <strong style={{color:'var(--text)', fontWeight:600}}>{lastSync}</strong></span>
         </div>
-        <button className="btn" onClick={() => alert('Settings · TODO')}>
-          <svg className="icon" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.4"/>
-            <path d="M8 1v2M8 13v2M15 8h-2M3 8H1M13.07 2.93l-1.41 1.41M4.34 11.66l-1.41 1.41M13.07 13.07l-1.41-1.41M4.34 4.34L2.93 2.93" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
-          </svg>
-        </button>
+        <ThemeToggle />
         <button className={`btn btn-primary ${collecting ? 'loading' : ''}`} onClick={onCollect} disabled={collecting || refreshing}>
-          <svg className={`icon ${collecting ? 'spin' : ''}`} viewBox="0 0 16 16" fill="none" style={{opacity:1}}>
-            <path d="M4 6.5h8M4 9.5h8" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round"/>
-            <path d="M3.5 4.5c0-.83 2.01-1.5 4.5-1.5s4.5.67 4.5 1.5v7c0 .83-2.01 1.5-4.5 1.5s-4.5-.67-4.5-1.5v-7Z" stroke="currentColor" strokeWidth="1.35"/>
-            <circle cx="8" cy="8" r="1.25" fill="currentColor"/>
+          <svg className={`icon ${collecting ? 'pulling' : ''}`} viewBox="0 0 16 16" fill="none" style={{opacity:1}}>
+            <path d="M8 2.5v7.5M5 7.5 8 10.5l3-3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M2.75 11.75v1c0 .41.34.75.75.75h9c.41 0 .75-.34.75-.75v-1" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/>
           </svg>
           {collecting ? '采集中' : '采集'}
         </button>

--- a/src/client/dashboard/styles.css
+++ b/src/client/dashboard/styles.css
@@ -1392,6 +1392,18 @@ button, input, select { font-family: inherit; color: inherit; }
   border-bottom: 1px solid oklch(0.34 0.02 265);
   transform: translateX(-50%) rotate(45deg);
 }
+/* Flipped under the cell when the rows above leave no room. */
+.heat-tooltip-below {
+  transform: translate(-50%, 9px);
+}
+.heat-tooltip-below::after {
+  bottom: auto;
+  top: -5px;
+  border-right: none;
+  border-bottom: none;
+  border-left: 1px solid oklch(0.34 0.02 265);
+  border-top: 1px solid oklch(0.34 0.02 265);
+}
 .heat-tooltip strong,
 .heat-tooltip span,
 .heat-tooltip small { display: block; }

--- a/src/client/dashboard/styles.css
+++ b/src/client/dashboard/styles.css
@@ -28,6 +28,34 @@
 
   --good:        oklch(0.55 0.14 145);
   --bad:         oklch(0.55 0.18 25);
+  --warn-text:   oklch(0.50 0.15 70);
+
+  /* Selected / active states — a wash of the indigo accent */
+  --accent-soft:        oklch(0.97 0.02 265);
+  --accent-soft-2:      oklch(0.95 0.025 265);
+  --accent-soft-border: oklch(0.85 0.04 265);
+  --on-accent:          oklch(0.995 0.005 80);   /* text on a filled accent */
+
+  --brand-from: oklch(0.30 0.04 265);
+  --brand-to:   oklch(0.20 0.02 265);
+  --btn-primary-hover: oklch(0.25 0.005 80);
+  --track: oklch(0.88 0.004 80);                 /* switch rail */
+  --knob:  oklch(1 0 0);
+  --scrim: oklch(0.18 0.005 80 / 0.30);          /* drawer backdrop */
+
+  /* Heatmap ramp — level 0 is the "no usage" cell */
+  --heat-0:   oklch(0.955 0.006 80);
+  --heat-1:   oklch(0.88 0.055 265);  --heat-1-edge: oklch(0.84 0.06 265);
+  --heat-2:   oklch(0.76 0.10 265);   --heat-2-edge: oklch(0.72 0.11 265);
+  --heat-3:   oklch(0.63 0.15 265);   --heat-3-edge: oklch(0.59 0.16 265);
+  --heat-4:   oklch(0.48 0.18 265);   --heat-4-edge: oklch(0.44 0.18 265);
+  --gauge-track: oklch(0.95 0.004 80);
+
+  /* Heatmap tooltip — deliberately inverted against the page */
+  --tip-bg:     oklch(0.20 0.012 265 / 0.96);
+  --tip-border: oklch(0.34 0.02 265);
+  --tip-text:   oklch(0.97 0.005 80);
+  --tip-muted:  oklch(0.77 0.01 265);
 
   --radius:      12px;
   --radius-sm:   8px;
@@ -36,9 +64,79 @@
   --shadow-sm: 0 1px 0 oklch(0.88 0.010 60);
   --shadow:    0 1px 3px rgb(60 40 20 / 0.05), 0 0 0 1px var(--border);
   --shadow-lg: 0 1px 3px rgb(60 40 20 / 0.05), 0 8px 24px -8px rgb(60 40 20 / 0.08), 0 0 0 1px var(--border);
+  --shadow-chip: 0 1px 2px rgb(0 0 0 / 0.06);
+  --shadow-pop:  0 8px 24px rgb(0 0 0 / 0.12);
+  --shadow-menu: 0 14px 36px -16px rgb(0 0 0 / 0.22);
+  --shadow-drawer: -20px 0 50px -20px rgb(0 0 0 / 0.12);
 
   --font: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* -------------------------------------------------------------
+   Dark theme — data-theme is always written explicitly (see the
+   pre-paint script in index.html) so a manual choice beats the OS.
+   ------------------------------------------------------------- */
+:root[data-theme="dark"] {
+  --bg:           oklch(0.17 0.008 80);
+  --surface:      oklch(0.21 0.008 80);
+  --surface-2:    oklch(0.25 0.008 80);
+  --surface-3:    oklch(0.29 0.008 80);
+  --border:       oklch(0.32 0.008 60);
+  --border-2:     oklch(0.27 0.008 60);
+  --line:         oklch(0.27 0.008 60);
+
+  --text:         oklch(0.94 0.006 60);
+  --text-2:       oklch(0.82 0.006 60);
+  --muted:        oklch(0.66 0.006 60);
+  --subtle:       oklch(0.50 0.005 60);
+
+  /* Accents lift in lightness so they keep contrast on a dark ground */
+  --c-indigo:    oklch(0.70 0.15 265);
+  --c-blue:      oklch(0.72 0.12 240);
+  --c-violet:    oklch(0.72 0.14 295);
+  --c-teal:      oklch(0.75 0.10 200);
+  --c-amber:     oklch(0.80 0.13 75);
+  --c-green:     oklch(0.74 0.11 150);
+  --c-rose:      oklch(0.70 0.15 20);
+
+  --good:        oklch(0.72 0.13 145);
+  --bad:         oklch(0.68 0.17 25);
+  --warn-text:   oklch(0.82 0.13 75);
+
+  --accent-soft:        oklch(0.30 0.045 265);
+  --accent-soft-2:      oklch(0.33 0.055 265);
+  --accent-soft-border: oklch(0.42 0.07 265);
+  --on-accent:          oklch(0.16 0.010 60);
+
+  --brand-from: oklch(0.62 0.13 265);
+  --brand-to:   oklch(0.45 0.11 265);
+  --btn-primary-hover: oklch(0.86 0.006 60);
+  --track: oklch(0.36 0.008 80);
+  --knob:  oklch(0.92 0.004 80);
+  --scrim: oklch(0.08 0.005 80 / 0.55);
+
+  --heat-0:   oklch(0.245 0.006 80);
+  --heat-1:   oklch(0.36 0.07 265);   --heat-1-edge: oklch(0.41 0.08 265);
+  --heat-2:   oklch(0.48 0.11 265);   --heat-2-edge: oklch(0.53 0.12 265);
+  --heat-3:   oklch(0.62 0.15 265);   --heat-3-edge: oklch(0.67 0.16 265);
+  --heat-4:   oklch(0.78 0.16 265);   --heat-4-edge: oklch(0.83 0.14 265);
+  --gauge-track: oklch(0.28 0.008 80);
+
+  --tip-bg:     oklch(0.30 0.012 265 / 0.97);
+  --tip-border: oklch(0.46 0.02 265);
+  --tip-text:   oklch(0.97 0.005 80);
+  --tip-muted:  oklch(0.80 0.01 265);
+
+  --shadow-sm: 0 1px 0 oklch(0.28 0.010 60);
+  --shadow:    0 1px 3px rgb(0 0 0 / 0.35), 0 0 0 1px var(--border);
+  --shadow-lg: 0 1px 3px rgb(0 0 0 / 0.35), 0 8px 24px -8px rgb(0 0 0 / 0.5), 0 0 0 1px var(--border);
+  --shadow-chip: 0 1px 2px rgb(0 0 0 / 0.4);
+  --shadow-pop:  0 8px 24px rgb(0 0 0 / 0.5);
+  --shadow-menu: 0 14px 36px -16px rgb(0 0 0 / 0.7);
+  --shadow-drawer: -20px 0 50px -20px rgb(0 0 0 / 0.6);
+
+  color-scheme: dark;
 }
 
 * { box-sizing: border-box; }
@@ -128,7 +226,7 @@ button, input, select { font-family: inherit; color: inherit; }
   width: 36px;
   height: 36px;
   border-radius: 10px;
-  background: linear-gradient(135deg, oklch(0.30 0.04 265), oklch(0.20 0.02 265));
+  background: linear-gradient(135deg, var(--brand-from), var(--brand-to));
   color: white;
   display: grid;
   place-items: center;
@@ -231,7 +329,7 @@ button, input, select { font-family: inherit; color: inherit; }
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 9px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-pop);
 }
 
 .quota-detail-row {
@@ -394,7 +492,7 @@ button, input, select { font-family: inherit; color: inherit; }
   color: var(--bg);
   border-color: var(--text);
 }
-.btn-primary:hover { background: oklch(0.25 0.005 80); border-color: oklch(0.25 0.005 80); }
+.btn-primary:hover { background: var(--btn-primary-hover); border-color: var(--btn-primary-hover); }
 
 .btn-icon {
   width: 30px; padding: 0;
@@ -494,7 +592,7 @@ button, input, select { font-family: inherit; color: inherit; }
 .chip.active {
   background: var(--surface);
   color: var(--text);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  box-shadow: var(--shadow-chip);
 }
 
 .time-range {
@@ -509,8 +607,8 @@ button, input, select { font-family: inherit; color: inherit; }
 }
 
 .time-range.active {
-  background: oklch(0.97 0.02 265);
-  border-color: oklch(0.85 0.04 265);
+  background: var(--accent-soft);
+  border-color: var(--accent-soft-border);
 }
 
 .time-sep {
@@ -537,8 +635,8 @@ button, input, select { font-family: inherit; color: inherit; }
 .dt-range-trigger:hover { background: var(--surface); }
 
 .dt-range-trigger.active {
-  background: oklch(0.97 0.02 265);
-  border-color: oklch(0.85 0.04 265);
+  background: var(--accent-soft);
+  border-color: var(--accent-soft-border);
 }
 
 .dt-range-hint {
@@ -594,7 +692,7 @@ button, input, select { font-family: inherit; color: inherit; }
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 14px 36px -16px rgb(0 0 0 / 0.22), 0 0 0 1px color-mix(in oklab, var(--border), transparent 20%);
+  box-shadow: var(--shadow-menu), 0 0 0 1px color-mix(in oklab, var(--border), transparent 20%);
 }
 
 .dt-head {
@@ -669,14 +767,14 @@ button, input, select { font-family: inherit; color: inherit; }
 }
 
 .dt-day.in-range {
-  background: oklch(0.95 0.025 265);
+  background: var(--accent-soft-2);
   color: var(--text);
   border-radius: 0;
 }
 
 .dt-day.active {
   background: var(--c-indigo);
-  color: #fff;
+  color: var(--on-accent);
   font-weight: 600;
   border-radius: 6px;
 }
@@ -732,8 +830,8 @@ button, input, select { font-family: inherit; color: inherit; }
 }
 
 .dt-now:hover {
-  background: oklch(0.97 0.02 265);
-  border-color: oklch(0.85 0.04 265);
+  background: var(--accent-soft);
+  border-color: var(--accent-soft-border);
 }
 
 .pill {
@@ -752,8 +850,8 @@ button, input, select { font-family: inherit; color: inherit; }
 }
 .pill:hover { background: var(--surface-2); }
 .pill.active {
-  background: oklch(0.97 0.02 265);
-  border-color: oklch(0.85 0.04 265);
+  background: var(--accent-soft);
+  border-color: var(--accent-soft-border);
   color: var(--c-indigo);
 }
 .pill-dot {
@@ -804,9 +902,9 @@ button, input, select { font-family: inherit; color: inherit; }
   color: var(--text-2);
   cursor: pointer;
 }
-.toggle.on { background: oklch(0.97 0.02 265); border-color: oklch(0.85 0.04 265); color: var(--c-indigo); }
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-soft-border); color: var(--c-indigo); }
 .toggle-slot {
-  width: 22px; height: 12px; background: oklch(0.88 0.004 80);
+  width: 22px; height: 12px; background: var(--track);
   border-radius: 999px; position: relative;
   transition: background 160ms ease;
 }
@@ -814,10 +912,10 @@ button, input, select { font-family: inherit; color: inherit; }
   content: '';
   position: absolute;
   width: 10px; height: 10px;
-  background: white;
+  background: var(--knob);
   border-radius: 50%;
   top: 1px; left: 1px;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.15);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.25);
   transition: transform 160ms ease;
 }
 .toggle.on .toggle-slot { background: var(--c-indigo); }
@@ -995,7 +1093,7 @@ button, input, select { font-family: inherit; color: inherit; }
 .tab.active {
   background: var(--surface);
   color: var(--text);
-  box-shadow: 0 1px 1px rgb(0 0 0 / 0.05);
+  box-shadow: var(--shadow-chip);
 }
 
 /* ─── Chart bodies ────────────────────────────────────────── */
@@ -1324,10 +1422,10 @@ button, input, select { font-family: inherit; color: inherit; }
 .heat-hour-bar > div {
   width: 100%;
   border-radius: 2px 2px 0 0;
-  background: oklch(0.63 0.15 265 / 0.75);
+  background: color-mix(in oklab, var(--c-indigo), transparent 25%);
   min-height: 0;
 }
-.heat-hour-bar:hover > div { background: oklch(0.48 0.18 265); }
+.heat-hour-bar:hover > div { background: var(--c-indigo); }
 .heat-cell:hover,
 .heat-cell:focus-visible {
   border-color: color-mix(in oklab, var(--text), transparent 25%);
@@ -1336,11 +1434,11 @@ button, input, select { font-family: inherit; color: inherit; }
   transform: scale(1.12);
   z-index: 2;
 }
-.heat-level-0 { background: oklch(0.955 0.006 80); }
-.heat-level-1 { background: oklch(0.88 0.055 265); border-color: oklch(0.84 0.06 265); }
-.heat-level-2 { background: oklch(0.76 0.10 265); border-color: oklch(0.72 0.11 265); }
-.heat-level-3 { background: oklch(0.63 0.15 265); border-color: oklch(0.59 0.16 265); }
-.heat-level-4 { background: oklch(0.48 0.18 265); border-color: oklch(0.44 0.18 265); }
+.heat-level-0 { background: var(--heat-0); }
+.heat-level-1 { background: var(--heat-1); border-color: var(--heat-1-edge); }
+.heat-level-2 { background: var(--heat-2); border-color: var(--heat-2-edge); }
+.heat-level-3 { background: var(--heat-3); border-color: var(--heat-3-edge); }
+.heat-level-4 { background: var(--heat-4); border-color: var(--heat-4-edge); }
 .heat-row-label,
 .heat-col-label {
   font-size: 10.5px;
@@ -1370,11 +1468,11 @@ button, input, select { font-family: inherit; color: inherit; }
   z-index: 10;
   min-width: 158px;
   padding: 9px 11px;
-  color: oklch(0.97 0.005 80);
-  background: oklch(0.20 0.012 265 / 0.96);
-  border: 1px solid oklch(0.34 0.02 265);
+  color: var(--tip-text);
+  background: var(--tip-bg);
+  border: 1px solid var(--tip-border);
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgb(20 18 30 / 0.20);
+  box-shadow: var(--shadow-pop);
   pointer-events: none;
   transform: translate(-50%, calc(-100% - 9px));
   text-align: left;
@@ -1419,7 +1517,7 @@ button, input, select { font-family: inherit; color: inherit; }
 }
 .heat-tooltip small {
   margin-top: 1px;
-  color: oklch(0.77 0.01 265);
+  color: var(--tip-muted);
   font-size: 10.5px;
 }
 
@@ -1610,7 +1708,7 @@ table.dt tbody tr {
   transition: background 100ms ease;
 }
 table.dt tbody tr:hover { background: var(--surface-2); }
-table.dt tbody tr.selected { background: oklch(0.97 0.02 265); }
+table.dt tbody tr.selected { background: var(--accent-soft); }
 
 .num { text-align: right; font-variant-numeric: tabular-nums; }
 .num-strong { font-weight: 600; }
@@ -1662,7 +1760,7 @@ table.dt tbody tr.selected { background: oklch(0.97 0.02 265); }
 }
 .status-ok    { background: color-mix(in oklab, var(--good), transparent 90%); color: var(--good); }
 .status-error { background: color-mix(in oklab, var(--bad),  transparent 90%); color: var(--bad);  }
-.status-warn  { background: color-mix(in oklab, var(--c-amber), transparent 85%); color: oklch(0.50 0.15 70); }
+.status-warn  { background: color-mix(in oklab, var(--c-amber), transparent 85%); color: var(--warn-text); }
 .status-empty { background: color-mix(in oklab, var(--muted), transparent 85%); color: var(--muted); }
 .status-skip  { background: color-mix(in oklab, var(--muted), transparent 85%); color: var(--muted); }
 
@@ -1670,7 +1768,7 @@ table.dt tbody tr.selected { background: oklch(0.97 0.02 265); }
 
 .drawer-backdrop {
   position: fixed; inset: 0;
-  background: oklch(0.18 0.005 80 / 0.30);
+  background: var(--scrim);
   backdrop-filter: blur(2px);
   z-index: 50;
   opacity: 0;
@@ -1686,7 +1784,7 @@ table.dt tbody tr.selected { background: oklch(0.97 0.02 265); }
   max-width: 92vw;
   background: var(--surface);
   border-left: 1px solid var(--border);
-  box-shadow: -20px 0 50px -20px rgb(0 0 0 / 0.12);
+  box-shadow: var(--shadow-drawer);
   z-index: 60;
   transform: translateX(100%);
   transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -1791,6 +1889,15 @@ table.dt tbody tr.selected { background: oklch(0.97 0.02 265); }
 }
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+/* Collect pulls data down, so its icon nudges rather than spins. */
+.pulling {
+  animation: pulling 900ms ease-in-out infinite;
+}
+@keyframes pulling {
+  0%, 100% { transform: translateY(-1px); opacity: 0.5; }
+  50%      { transform: translateY(1px);  opacity: 1; }
 }
 
 /* responsive — small fallback */

--- a/src/client/main.jsx
+++ b/src/client/main.jsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './dashboard/App.jsx';
 import { ReviewApp } from './review/ReviewApp.jsx';
+import { ThemeProvider } from './shared/theme.js';
 
 function Root() {
   if (window.location.pathname === '/review') {
@@ -12,4 +13,8 @@ function Root() {
   return <App />;
 }
 
-createRoot(document.getElementById('root')).render(<Root />);
+createRoot(document.getElementById('root')).render(
+  <ThemeProvider>
+    <Root />
+  </ThemeProvider>
+);

--- a/src/client/review/ReviewApp.jsx
+++ b/src/client/review/ReviewApp.jsx
@@ -5,6 +5,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { U } from '../shared/utils.js';
 import { RU } from './utils.js';
+import { ThemeToggle } from '../shared/ThemeToggle.jsx';
 import { HeroSection, ProjectSection, CalendarSection } from './sections-1.jsx';
 import { ToolsSection, EfficiencySection, InsightsSection } from './sections-2.jsx';
 import './styles.css';
@@ -167,6 +168,7 @@ function ReviewDashboard({ rawData }) {
             ))}
           </div>
           <div className="nav-actions">
+            <ThemeToggle className="nav-btn" />
             <button className="nav-btn" onClick={() => window.print()}>
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
                 <rect x="2.5" y="4.5" width="8" height="6" rx="1" stroke="currentColor" strokeWidth="1.3"/>

--- a/src/client/review/sections-2.jsx
+++ b/src/client/review/sections-2.jsx
@@ -6,11 +6,13 @@ import { useMemo, useState } from 'react';
 import { U } from '../shared/utils.js';
 import { EChart } from '../shared/echart.jsx';
 import { RU } from './utils.js';
+import { chartPalette, useTheme } from '../shared/theme.js';
 
 // ───────────────────────────────────────────────────────────────
 // Tools donut + per-tool list
 // ───────────────────────────────────────────────────────────────
 function ToolsSection({ daily, totalTokens }) {
+  const pal = chartPalette(useTheme().theme);
   const tools = useMemo(() => {
     const list = RU.aggregateBy(daily, 'source').sort((a, b) => b.totalTokens - a.totalTokens);
     return list.map(t => ({
@@ -29,10 +31,10 @@ function ToolsSection({ daily, totalTokens }) {
       appendToBody: true,
       confine: true,
       transitionDuration: 0,
-      backgroundColor: '#fff',
-      borderColor: 'oklch(0.92 0.004 80)',
+      backgroundColor: pal.tooltipBg,
+      borderColor: pal.tooltipBorder,
       borderWidth: 1,
-      textStyle: { color: 'oklch(0.18 0.005 80)', fontSize: 12 },
+      textStyle: { color: pal.tooltipText, fontSize: 12 },
       extraCssText: 'pointer-events:none;box-shadow:0 8px 24px rgb(0 0 0 / 0.08);border-radius:8px;',
       formatter: p => `<div style="font-weight:600;margin-bottom:4px">${p.name}</div>
         <div style="font-size:14px;font-weight:600">${U.compactCN(p.value)} tokens</div>
@@ -51,7 +53,7 @@ function ToolsSection({ daily, totalTokens }) {
       labelLine: { show: false },
       itemStyle: {
         borderRadius: 8,
-        borderColor: '#fff',
+        borderColor: pal.sliceBorder,
         borderWidth: 2,
         shadowBlur: 12,
         shadowOffsetY: 3,
@@ -71,7 +73,7 @@ function ToolsSection({ daily, totalTokens }) {
           itemStyle: {
             color: U.getSourceColor(t.key),
             opacity: 1,
-            borderColor: '#fff',
+            borderColor: pal.sliceBorder,
             borderWidth: 2,
             shadowBlur: 12,
             shadowOffsetY: 3,
@@ -80,7 +82,7 @@ function ToolsSection({ daily, totalTokens }) {
         }
       }))
     }]
-  }), [tools]);
+  }), [tools, pal]);
 
   if (!tools.length) return null;
   const top = tools[0];

--- a/src/client/review/styles.css
+++ b/src/client/review/styles.css
@@ -26,9 +26,45 @@
   --good:      oklch(0.55 0.14 145);
   --bad:       oklch(0.55 0.18 25);
 
+  --bar-to:    oklch(0.45 0.18 280);   /* foot of the vertical accent bar */
+  --card-lift: oklch(0.985 0.006 80);  /* card face lifted off the paper */
+  --btn-solid-hover: oklch(0.25 0.010 60);
+
   --serif: 'Instrument Serif', 'Source Serif 4', Georgia, serif;
   --sans:  'Inter', system-ui, -apple-system, sans-serif;
   --mono:  'JetBrains Mono', ui-monospace, Menlo, monospace;
+}
+
+/* -------------------------------------------------------------
+   Dark theme — mirrors the dashboard's `data-theme` contract so a
+   single toggle drives both pages.
+   ------------------------------------------------------------- */
+:root[data-theme="dark"] {
+  --paper:        oklch(0.17 0.008 80);
+  --paper-2:      oklch(0.21 0.008 80);
+  --paper-3:      oklch(0.25 0.008 80);
+  --ink:          oklch(0.94 0.006 60);
+  --ink-2:        oklch(0.82 0.006 60);
+  --ink-3:        oklch(0.66 0.006 60);
+  --ink-soft:     oklch(0.50 0.005 60);
+
+  --rule:         oklch(0.32 0.008 60);
+  --rule-2:       oklch(0.27 0.008 60);
+
+  --indigo:    oklch(0.70 0.15 265);
+  --violet:    oklch(0.72 0.14 295);
+  --teal:      oklch(0.72 0.11 200);
+  --amber:     oklch(0.80 0.13 70);
+  --green:     oklch(0.72 0.12 145);
+  --bad:       oklch(0.70 0.16 25);
+  --rose:      oklch(0.70 0.16 25);
+  --good:      oklch(0.72 0.13 145);
+
+  --bar-to:    oklch(0.58 0.16 280);
+  --card-lift: oklch(0.225 0.008 80);
+  --btn-solid-hover: oklch(0.86 0.006 60);
+
+  color-scheme: dark;
 }
 
 * { box-sizing: border-box; }
@@ -54,7 +90,7 @@ body::before {
   inset: 0;
   pointer-events: none;
   background-image:
-    radial-gradient(oklch(0.55 0.02 60 / 0.025) 1px, transparent 1px);
+    radial-gradient(color-mix(in oklab, var(--ink), transparent 97.5%) 1px, transparent 1px);
   background-size: 3px 3px;
   z-index: 0;
   opacity: 0.6;
@@ -285,7 +321,7 @@ section.story:last-of-type  { padding-bottom: 56px; }
   font-feature-settings: 'lnum', 'ss01';
   font-variant-numeric: lining-nums;
   display: inline-block;
-  background: linear-gradient(180deg, var(--indigo) 30%, oklch(0.45 0.18 280) 100%);
+  background: linear-gradient(180deg, var(--indigo) 30%, var(--bar-to) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -536,8 +572,8 @@ section.story:last-of-type  { padding-bottom: 56px; }
   box-shadow: 0 8px 24px -8px rgb(0 0 0 / 0.4);
   transform: translate(-50%, -120%);
 }
-.cal-tip b { color: oklch(0.85 0.05 70); }
-.cal-tip .dim { color: oklch(0.65 0.005 80); font-weight: 400; margin-left: 8px; }
+.cal-tip b { color: var(--amber); }
+.cal-tip .dim { color: var(--ink-3); font-weight: 400; margin-left: 8px; }
 
 .cal-scale {
   display: inline-flex; align-items: center; gap: 6px;
@@ -773,7 +809,7 @@ section.story:last-of-type  { padding-bottom: 56px; }
   position: relative;
 }
 .insight:hover {
-  background: oklch(0.985 0.006 80);
+  background: var(--card-lift);
   border-color: var(--rule);
 }
 .insight-head {
@@ -912,7 +948,7 @@ section.story:last-of-type  { padding-bottom: 56px; }
   font-size: 13px;
   font-weight: 500;
 }
-.export-btn:hover { background: oklch(0.25 0.010 60); }
+.export-btn:hover { background: var(--btn-solid-hover); }
 
 /* ─── Misc ───────────────────────────────────────────────── */
 

--- a/src/client/shared/ThemeToggle.jsx
+++ b/src/client/shared/ThemeToggle.jsx
@@ -1,0 +1,30 @@
+/* =============================================================
+   Theme toggle — shared by both pages, so it carries its own icon
+   sizing instead of relying on either page's stylesheet.
+   ============================================================= */
+
+import { useTheme } from './theme.js';
+
+// Shows the theme it switches TO, so the icon reads as the action.
+export function ThemeToggle({ className = 'btn btn-icon' }) {
+  const { theme, toggleTheme } = useTheme();
+  const goingDark = theme === 'light';
+  const label = goingDark ? '切换到暗色主题' : '切换到亮色主题';
+
+  return (
+    <button className={className} onClick={toggleTheme} title={label} aria-label={label}>
+      {goingDark ? (
+        <svg className="icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M13.4 9.6A5.6 5.6 0 0 1 6.4 2.6a5.6 5.6 0 1 0 7 7Z"
+            stroke="currentColor" strokeWidth="1.35" strokeLinejoin="round"/>
+        </svg>
+      ) : (
+        <svg className="icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="8" cy="8" r="3.1" stroke="currentColor" strokeWidth="1.35"/>
+          <path d="M8 1.2v1.6M8 13.2v1.6M14.8 8h-1.6M2.8 8H1.2M12.8 3.2l-1.1 1.1M4.3 11.7l-1.1 1.1M12.8 12.8l-1.1-1.1M4.3 4.3 3.2 3.2"
+            stroke="currentColor" strokeWidth="1.35" strokeLinecap="round"/>
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/client/shared/theme.js
+++ b/src/client/shared/theme.js
@@ -1,0 +1,128 @@
+/* =============================================================
+   Theme — the resolved theme is written to <html data-theme>, so a
+   manual choice can override the OS instead of racing @media rules.
+   ============================================================= */
+
+import { createContext, createElement, useCallback, useContext, useEffect, useState } from 'react';
+
+export const THEME_KEY = 'ts-theme';
+const THEMES = ['light', 'dark'];
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+/**
+ * Decide which theme to show. A stored manual choice always wins;
+ * otherwise follow the OS. Both inputs are passed in so the rule stays
+ * pure and testable without a DOM.
+ */
+export function resolveTheme(stored, prefersDark) {
+  if (THEMES.includes(stored)) return stored;
+  return prefersDark ? 'dark' : 'light';
+}
+
+// localStorage throws in private mode / blocked-cookie setups; a missing
+// preference is not worth breaking the page over.
+function readStored() {
+  try {
+    return localStorage.getItem(THEME_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(theme) {
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    /* preference just won't persist */
+  }
+}
+
+const ThemeContext = createContext({ theme: 'light', toggleTheme: () => {} });
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(
+    () => resolveTheme(readStored(), window.matchMedia(DARK_QUERY).matches)
+  );
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  // Track the OS only until the user picks a side; after that the stored
+  // choice sticks even when the system flips.
+  useEffect(() => {
+    const query = window.matchMedia(DARK_QUERY);
+    const onChange = event => {
+      if (readStored()) return;
+      setTheme(event.matches ? 'dark' : 'light');
+    };
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(current => {
+      const next = current === 'dark' ? 'light' : 'dark';
+      writeStored(next);
+      return next;
+    });
+  }, []);
+
+  return createElement(ThemeContext.Provider, { value: { theme, toggleTheme } }, children);
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+/**
+ * ECharts paints to canvas and cannot read CSS custom properties, so chart
+ * chrome carries its own palette. Keep these in step with the `:root` and
+ * `:root[data-theme="dark"]` blocks in the page stylesheets.
+ */
+const CHART_PALETTES = {
+  light: {
+    axisLine:       'oklch(0.92 0.004 80)',
+    splitLine:      'oklch(0.95 0.004 80)',
+    axisLabel:      'oklch(0.55 0.005 80)',
+    axisLabelDim:   'oklch(0.62 0.004 80)',
+    tooltipBg:      'oklch(0.995 0.004 80)',
+    tooltipBorder:  'oklch(0.92 0.004 80)',
+    tooltipText:    'oklch(0.18 0.005 80)',
+    tooltipLabel:   'oklch(0.40 0.005 80)',
+    tooltipMuted:   'oklch(0.55 0.005 80)',
+    tooltipSeries:  'oklch(0.45 0.005 80)',
+    markLine:       'oklch(0.72 0.005 80)',
+    markLineCompare:'oklch(0.45 0.04 265)',
+    crossHair:      'oklch(0.62 0.04 265 / 0.45)',
+    zoomBg:         'oklch(0.97 0.004 80)',
+    zoomFiller:     'oklch(0.92 0.02 265 / 0.5)',
+    zoomHandle:     'oklch(0.995 0.004 80)',
+    zoomHandleEdge: 'oklch(0.55 0.16 265)',
+    sliceBorder:    'oklch(0.995 0.005 80)'
+  },
+  dark: {
+    axisLine:       'oklch(0.32 0.008 60)',
+    splitLine:      'oklch(0.27 0.008 60)',
+    axisLabel:      'oklch(0.66 0.006 60)',
+    axisLabelDim:   'oklch(0.58 0.006 60)',
+    tooltipBg:      'oklch(0.26 0.010 80)',
+    tooltipBorder:  'oklch(0.36 0.010 80)',
+    tooltipText:    'oklch(0.95 0.005 80)',
+    tooltipLabel:   'oklch(0.78 0.005 80)',
+    tooltipMuted:   'oklch(0.66 0.005 80)',
+    tooltipSeries:  'oklch(0.80 0.005 80)',
+    markLine:       'oklch(0.50 0.008 80)',
+    markLineCompare:'oklch(0.72 0.06 265)',
+    crossHair:      'oklch(0.72 0.06 265 / 0.5)',
+    zoomBg:         'oklch(0.24 0.008 80)',
+    zoomFiller:     'oklch(0.50 0.05 265 / 0.45)',
+    zoomHandle:     'oklch(0.30 0.010 80)',
+    zoomHandleEdge: 'oklch(0.70 0.15 265)',
+    sliceBorder:    'oklch(0.21 0.008 80)'
+  }
+};
+
+export function chartPalette(theme) {
+  return CHART_PALETTES[theme] || CHART_PALETTES.light;
+}

--- a/test/theme.test.mjs
+++ b/test/theme.test.mjs
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveTheme, chartPalette } from '../src/client/shared/theme.js';
+
+test('resolveTheme follows the OS when nothing is stored', () => {
+  assert.equal(resolveTheme(null, true), 'dark');
+  assert.equal(resolveTheme(null, false), 'light');
+});
+
+test('resolveTheme lets a stored choice override the OS', () => {
+  assert.equal(resolveTheme('light', true), 'light');
+  assert.equal(resolveTheme('dark', false), 'dark');
+});
+
+test('resolveTheme ignores junk in storage and falls back to the OS', () => {
+  assert.equal(resolveTheme('', true), 'dark');
+  assert.equal(resolveTheme('midnight', false), 'light');
+  assert.equal(resolveTheme(undefined, true), 'dark');
+});
+
+test('both chart palettes define the same keys', () => {
+  const light = chartPalette('light');
+  const dark = chartPalette('dark');
+  assert.deepEqual(Object.keys(light).sort(), Object.keys(dark).sort());
+  for (const [key, value] of Object.entries(dark)) {
+    assert.notEqual(value, light[key], `${key} should differ between themes`);
+  }
+});
+
+test('chartPalette falls back to light for an unknown theme', () => {
+  assert.equal(chartPalette('nope'), chartPalette('light'));
+});


### PR DESCRIPTION
Two independent changes, one commit each.

## `fix:` heatmap tooltip placement

The tooltip was positioned from two hardcoded guesses, both wrong. Measured in Chrome:

- **Top clipped.** `.heatmap-scroll` sets `overflow-x: auto`, which forces `overflow-y` to compute to `auto` too, so it clips vertically. The `42px` padding-top reserved for the tooltip falls short of the `106.78px` a four-line tooltip needs above the first row — the top `45.78px` was cut off. Even the two-line "no usage" variant lost `10px`.
- **Arrow rendered as a diamond.** The horizontal clamp used a half-width of `92px` against a tooltip that is actually `158px` wide, pushing `--arrow-shift` to `77.55px` and the arrow's `left` to `155.5px` in a `156px` padding box. The rotated square hung off the corner, lost the tooltip background that normally covers its top half, and showed all four edges.

Now positioned from the tooltip's real box in a layout effect (runs before paint, so the unmeasured pass is never visible): clamp by the measured half-width, cap the arrow shift so it stays on the body, and flip below the cell when the rows above cannot fit it.

Verified across 8 edge cells (first/middle/last row × leftmost/middle/rightmost column) — all four clip margins negative, arrow fully inside the body, and no horizontal scrollbar (the problem the original clamp existed to prevent).

## `feat:` dark theme + collect icon

The settings button was a placeholder that alerted `Settings · TODO`. It is now a real theme toggle, on both the dashboard and the review page.

- **State.** The resolved theme is always written to `<html data-theme>` rather than driven by `@media`, so a manual choice can override the OS. A pre-paint inline script in `index.html` applies it before first paint. The app follows OS changes only until the user picks a side; after that the stored choice sticks.
- **Styles.** Both stylesheets gain a `:root[data-theme="dark"]` block. The 45 colours that sat outside the token set — heatmap ramp, selected-state washes, shadows, drawer scrim, tooltip — became semantic tokens. Accents lift in lightness to hold contrast on a dark ground.
- **Charts.** ECharts paints to canvas and cannot read CSS variables, so chart chrome comes from `chartPalette(theme)` (34 call sites). The review donut memoises its option, so the palette joins its dependency list or it keeps stale colours across a flip.
- **Collect icon.** Database glyph → download arrow, and its loading animation changes from `spin` to a nudge, since a spinning download arrow reads as broken.

## Verification

- `npm test` 47/47 (5 new: `resolveTheme` precedence, and a check that both chart palettes define the same keys so a token cannot go missing).
- `npm run build` clean. Commit 1 was tested and built in isolation to confirm it stands alone.
- Browser audit, 21 assertions, all passing: OS-follow with nothing stored, toggle persists, a stored choice survives reload under an opposing OS setting, no light containers left in dark mode, sampled text ≥ 4.5:1 in both themes on both pages, and the ECharts tooltip follows the theme.

One note on that audit: the first version of the check was wrong — it read identical luminance for both themes because Chrome returns computed colours as `oklch(...)` and the parser treated those numbers as sRGB. Fixed by painting each colour to a 1×1 canvas and reading the pixel back. The corrected check flagged `.btn-primary` as a light surface in dark mode; that is the intended inverted solid button (light face, dark label, 15:1), so the rule was changed from absolute luminance to contrast ratio.