### PR TITLE
fix: draw the cache gauge arc at its real radius

### DIFF
--- a/src/client/dashboard/components-charts.jsx
+++ b/src/client/dashboard/components-charts.jsx
@@ -9,6 +9,7 @@ import { EChart } from '../shared/echart.jsx';
 import { Delta, Spark } from './components-top.jsx';
 import { sourceIcon, sourceIconScale } from './source-icons.js';
 import { chartPalette, useTheme } from '../shared/theme.js';
+import { GAUGE, GAUGE_PATH, gaugeDash } from '../shared/gauge.js';
 
 // ───────────────────────────────────────────────────────────────
 // Trend chart — switchable bar/line/stacked + optional comparison
@@ -760,8 +761,6 @@ function Heatmap({ rows, dates, loading = false, error = null }) {
 // ───────────────────────────────────────────────────────────────
 function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitRateSeries }) {
   const r = Math.max(0, Math.min(100, rate));
-  const C = Math.PI * 70;
-  const dash = (r / 100) * C;
 
   return (
     <div className="panel cache-card">
@@ -774,13 +773,13 @@ function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitR
       </div>
       <div className="gauge">
         <div className="gauge-wrap">
-          <svg viewBox="0 0 180 100" width="180" height="100">
-            <path d="M 10 90 A 80 80 0 0 1 170 90" stroke="var(--gauge-track)" strokeWidth="14" fill="none" strokeLinecap="round"/>
+          <svg viewBox={GAUGE.viewBox} width="180" height="100">
+            <path d={GAUGE_PATH} stroke="var(--gauge-track)" strokeWidth="14" fill="none" strokeLinecap="round"/>
             <path
-              d="M 10 90 A 80 80 0 0 1 170 90"
+              d={GAUGE_PATH}
               stroke="url(#hitGrad)"
               strokeWidth="14" fill="none" strokeLinecap="round"
-              strokeDasharray={`${dash} ${C}`}
+              strokeDasharray={gaugeDash(r)}
               style={{transition: 'stroke-dasharray 600ms cubic-bezier(0.22,1,0.36,1)'}}
             />
             <defs>

--- a/src/client/shared/gauge.js
+++ b/src/client/shared/gauge.js
@@ -1,0 +1,30 @@
+/* =============================================================
+   Semicircular gauge geometry.
+
+   The arc path and the dash length are derived from one radius, so
+   the drawn fraction can never drift from the number beside it.
+   ============================================================= */
+
+export const GAUGE = {
+  radius: 80,
+  cx: 90,
+  cy: 90,
+  viewBox: '0 0 180 100'
+};
+
+/** The `d` of the half-circle both the track and the progress arc use. */
+export const GAUGE_PATH =
+  `M ${GAUGE.cx - GAUGE.radius} ${GAUGE.cy} `
+  + `A ${GAUGE.radius} ${GAUGE.radius} 0 0 1 ${GAUGE.cx + GAUGE.radius} ${GAUGE.cy}`;
+
+/** Length of that half-circle. */
+export const GAUGE_LENGTH = Math.PI * GAUGE.radius;
+
+/**
+ * Dash pattern that fills `percent` of the arc.
+ * Out-of-range input is clamped so a bad rate cannot overdraw the track.
+ */
+export function gaugeDash(percent) {
+  const clamped = Math.max(0, Math.min(100, Number(percent) || 0));
+  return `${(clamped / 100) * GAUGE_LENGTH} ${GAUGE_LENGTH}`;
+}

--- a/test/gauge.test.mjs
+++ b/test/gauge.test.mjs
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GAUGE, GAUGE_PATH, GAUGE_LENGTH, gaugeDash } from '../src/client/shared/gauge.js';
+
+const dashOf = percent => Number(gaugeDash(percent).split(' ')[0]);
+
+test('the path and the dash length come from the same radius', () => {
+  // Regression: the arc was drawn at r=80 while the dash used pi*70, so the
+  // gauge silently under-filled by 12.5% and could never reach 100%.
+  const [, rx, ry] = GAUGE_PATH.match(/A (\d+(?:\.\d+)?) (\d+(?:\.\d+)?)/);
+  assert.equal(Number(rx), GAUGE.radius);
+  assert.equal(Number(ry), GAUGE.radius);
+  assert.equal(GAUGE_LENGTH, Math.PI * GAUGE.radius);
+});
+
+test('the path spans the full half-circle around the centre', () => {
+  assert.equal(GAUGE_PATH, 'M 10 90 A 80 80 0 0 1 170 90');
+});
+
+test('gaugeDash fills the arc in proportion to the percentage', () => {
+  assert.equal(dashOf(0), 0);
+  assert.equal(dashOf(100), GAUGE_LENGTH);
+  assert.equal(dashOf(50), GAUGE_LENGTH / 2);
+  assert.ok(Math.abs(dashOf(95.9) / GAUGE_LENGTH - 0.959) < 1e-9);
+});
+
+test('gaugeDash clamps out-of-range and non-numeric input', () => {
+  assert.equal(dashOf(150), GAUGE_LENGTH);
+  assert.equal(dashOf(-20), 0);
+  assert.equal(dashOf(NaN), 0);
+  assert.equal(dashOf(undefined), 0);
+});
+
+test('the unfilled remainder always covers the rest of the arc', () => {
+  for (const percent of [0, 12.5, 50, 87.5, 100]) {
+    const [drawn, gap] = gaugeDash(percent).split(' ').map(Number);
+    assert.ok(drawn + gap >= GAUGE_LENGTH, `${percent}% leaves a repeat gap`);
+  }
+});


### PR DESCRIPTION
Reported as "the cache gauge looks like a fixed value". The number does track the data — but the **arc** was drawn wrong.

## Root cause

`Gauge` drew its path as a half-circle of radius 80 (`A 80 80`) but computed the dash length from `Math.PI * 70`. The drawn fraction was therefore always `rate × 70/80` — a flat **12.5% short** — and a full 100% could only ever reach 87.5% of the track.

Measured in the browser before the fix, across the time filters:

| Filter | Printed | Actually drawn | Error |
|---|---|---|---|
| 7 天 | 94.9% | 83.07% | −11.83pt |
| 14 天 | 97.3% | 85.10% | −12.20pt |
| 30 天 | 95.9% | 83.94% | −11.96pt |
| 90 天 | 96.2% | 84.16% | −12.04pt |
| 全部 | 89.3% | 78.11% | −11.19pt |

The browser reports the path's real length as 251.36 (`π×80 = 251.33`); the code was dividing against 219.91 (`π×70`).

## Fix

Moved the geometry into `src/client/shared/gauge.js`, where the path `d` and the dash length are both derived from a single `radius`, so the two can no longer drift apart. Input is clamped there as well, so an out-of-range rate cannot overdraw the track.

After the fix the drawn fraction tracks the printed number to within the rounding of its one decimal:

```
7 天    94.9%  ->  94.93% drawn   (+0.03pt)
14 天   97.3%  ->  97.25% drawn   (-0.05pt)
30 天   95.9%  ->  95.94% drawn   (+0.04pt)
全部    89.3%  ->  89.27% drawn   (-0.03pt)
```

## Tests

`test/gauge.test.mjs` — 5 cases covering the radius/length agreement, the exact path, proportional fill, clamping of out-of-range and non-numeric input, and that the dash remainder always covers the rest of the arc.

The regression test was verified to actually catch this bug: re-injecting `Math.PI * 70` makes case 1 fail, and restoring the fix makes it pass again.

`npm test` 52/52, `npm run build` clean.