### PR TITLE
fix: let the hit-rate sparkline scale to its own range

### DIFF
--- a/src/client/dashboard/components-charts.jsx
+++ b/src/client/dashboard/components-charts.jsx
@@ -761,6 +761,11 @@ function Heatmap({ rows, dates, loading = false, error = null }) {
 // ───────────────────────────────────────────────────────────────
 function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitRateSeries }) {
   const r = Math.max(0, Math.min(100, rate));
+  // The sparkline below scales to its own range, so name that range rather than
+  // letting a non-zero floor imply the line starts at 0.
+  const span = hitRateSeries?.length
+    ? { lo: Math.min(...hitRateSeries), hi: Math.max(...hitRateSeries) }
+    : null;
 
   return (
     <div className="panel cache-card">
@@ -812,8 +817,10 @@ function Gauge({ rate, cacheRead, cacheCreation, total, prevRate, savedUSD, hitR
       <div className="cache-trend">
         <div className="cache-trend-head">
           <span>每日命中率</span>
+          {span && <small>{span.lo.toFixed(1)}% – {span.hi.toFixed(1)}%</small>}
         </div>
-        <Spark values={hitRateSeries} color="var(--c-teal)" height={36}/>
+        {/* Scaled to its own range, so the label above states that range. */}
+        <Spark values={hitRateSeries} color="var(--c-teal)" height={36} baseline="auto"/>
       </div>
     </div>
   );

--- a/src/client/dashboard/components-top.jsx
+++ b/src/client/dashboard/components-top.jsx
@@ -536,11 +536,17 @@ function MultiSelect({ options, selected, onChange, placeholder }) {
 // ───────────────────────────────────────────────────────────────
 // Sparkline SVG
 // ───────────────────────────────────────────────────────────────
-function Spark({ values, color, height = 30, fill = true }) {
+/**
+ * `baseline` picks the floor of the y-axis. Token counts are magnitudes, so
+ * they anchor at zero; a rate that lives between 89% and 97% would be flattened
+ * into a couple of pixels by a zero floor, so those pass 'auto' to let the
+ * series fill the box.
+ */
+function Spark({ values, color, height = 30, fill = true, baseline = 0 }) {
   if (!values || values.length === 0) return null;
   const w = 100, h = height;
-  const max = Math.max(...values, 1);
-  const min = Math.min(...values, 0);
+  const max = Math.max(...values, baseline === 'auto' ? -Infinity : 1);
+  const min = baseline === 'auto' ? Math.min(...values) : Math.min(...values, 0);
   const range = max - min || 1;
   const pts = values.map((v, i) => {
     const x = (i / (values.length - 1 || 1)) * w;

--- a/src/client/dashboard/styles.css
+++ b/src/client/dashboard/styles.css
@@ -1341,11 +1341,20 @@ button, input, select { font-family: inherit; color: inherit; }
 .cache-trend-head {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
   font-size: 10.5px;
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   margin-bottom: 4px;
+}
+/* The sparkline's own range — it does not start at zero. */
+.cache-trend-head small {
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--subtle);
 }
 .cache-trend .kpi-spark {
   position: static;


### PR DESCRIPTION
Follow-up to #8, chasing the rest of "the cache gauge looks static".

`Spark` forced its y-axis floor to zero (`Math.min(...values, 0)`). That is correct for the KPI sparklines, which plot token counts — magnitudes where zero is the meaningful origin. It is wrong for the cache hit rate, which lives near the top of a 0–100 scale: a 89–98% series was squeezed into the top few percent of a 36px box, leaving roughly 2.5px of vertical movement, and read as a flat line.

Adds a `baseline` prop defaulting to `0`, so both existing call sites are byte-for-byte unchanged, and the gauge card passes `'auto'`. Because the line no longer starts at zero, the card now prints the range it actually covers next to the label, so a non-zero floor cannot be misread as one.

**On how much this actually helps:** less than I expected, and worth stating plainly. On the current data the daily series spans **36.3%–98.4%** — two outlier days set the floor — so the typical 94–97% band still occupies a narrow slice. The change is right in principle and helps whenever the range is genuinely tight, but it does not make a stable metric look dynamic, and it should not.

`npm test` 52/52, `npm run build` clean.