### PR TITLE
fix: stop an unknown quota window from displacing a real one

### DIFF
--- a/src/client/dashboard/components-top.jsx
+++ b/src/client/dashboard/components-top.jsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { U } from '../shared/utils.js';
 import { ThemeToggle } from '../shared/ThemeToggle.jsx';
+import { quotaWindowLabel, orderQuotaWindows } from '../shared/quota.js';
 import tokenStudioFlow from '../assets/token-studio-flow.png';
 import claudeIcon from './icons/claude.svg';
 import gptIcon from './icons/gpt.svg';
@@ -15,13 +16,6 @@ const QUOTA_TOOL_ICON = { Claude: claudeIcon, Codex: gptIcon };
 // ───────────────────────────────────────────────────────────────
 // Subscription-window quota bars (live, from /api/quota)
 // ───────────────────────────────────────────────────────────────
-const QUOTA_WINDOW_LABEL = {
-  five_hour: '5 小时',
-  seven_day: '7 天',
-  seven_day_opus: '7 天 · Opus',
-  seven_day_sonnet: '7 天 · Sonnet'
-};
-
 function quotaResetText(iso) {
   if (!iso) return '';
   const ms = new Date(iso).getTime() - Date.now();
@@ -35,15 +29,13 @@ function quotaResetText(iso) {
   return `${m}m 后重置`;
 }
 
-const QUOTA_WINDOW_ORDER = ['five_hour', 'seven_day', 'seven_day_opus', 'seven_day_sonnet'];
-
 function QuotaWindowRow({ window }) {
   const pct = Math.round((window.utilization || 0) * 100);
   const tone = pct >= 90 ? 'bad' : pct >= 70 ? 'warn' : 'ok';
   return (
     <div className="quota-row">
       <div className="quota-row-head">
-        <span className="quota-win">{QUOTA_WINDOW_LABEL[window.name] || window.name}</span>
+        <span className="quota-win">{quotaWindowLabel(window.name)}</span>
         <span className="quota-reset">{quotaResetText(window.resetsAt)}</span>
         <span className="quota-pct">{pct}%</span>
       </div>
@@ -91,9 +83,7 @@ function quotaAccountRows(account) {
 function QuotaItem({ tool, windows, error, account }) {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
-  const ordered = (windows || []).slice().sort(
-    (a, b) => QUOTA_WINDOW_ORDER.indexOf(a.name) - QUOTA_WINDOW_ORDER.indexOf(b.name)
-  ).slice(0, 2);
+  const ordered = orderQuotaWindows(windows).slice(0, 2);
   const hasDetail = !!(account && (account.email || account.plan)) || ordered.length > 0;
 
   // Close the detail popover when clicking anywhere outside the card.
@@ -128,7 +118,7 @@ function QuotaItem({ tool, windows, error, account }) {
           {ordered.length > 0 && <div className="quota-detail-sep" />}
           {ordered.map(w => (
             <div className="quota-detail-row" key={w.name}>
-              <span>{QUOTA_WINDOW_LABEL[w.name] || w.name}重置</span>
+              <span>{quotaWindowLabel(w.name)}重置</span>
               <b>{quotaResetAbs(w.resetsAt)}</b>
             </div>
           ))}

--- a/src/client/shared/quota.js
+++ b/src/client/shared/quota.js
@@ -1,0 +1,50 @@
+/* =============================================================
+   Subscription quota windows.
+
+   Vendors add windows without warning — Anthropic started returning
+   a `nimbus_quill` window with no reset time and zero utilization.
+   Anything unrecognised has to degrade quietly: it must never take a
+   slot from a real limit, and it must never be mistaken for one.
+   ============================================================= */
+
+export const QUOTA_WINDOW_LABEL = {
+  five_hour: '5 小时',
+  seven_day: '7 天',
+  seven_day_opus: '7 天 · Opus',
+  seven_day_sonnet: '7 天 · Sonnet'
+};
+
+const QUOTA_WINDOW_ORDER = ['five_hour', 'seven_day', 'seven_day_opus', 'seven_day_sonnet'];
+
+/** Chinese label for a known window; the raw vendor name otherwise. */
+export function quotaWindowLabel(name) {
+  return QUOTA_WINDOW_LABEL[name] || name;
+}
+
+/**
+ * A window we do not recognise that also carries no reset time and no
+ * usage is a vendor placeholder, not a limit the user is spending against.
+ */
+function isEmptyUnknown(window) {
+  return !QUOTA_WINDOW_LABEL[window?.name]
+    && !window?.resetsAt
+    && !(Number(window?.utilization) > 0);
+}
+
+/**
+ * Known windows first, in the order above; anything unrecognised keeps its
+ * relative order behind them. `indexOf` returns -1 for unknown names, so
+ * sorting on it raw would float them to the front and push a real window out
+ * of the card's two-row slice.
+ */
+export function orderQuotaWindows(windows) {
+  const rank = name => {
+    const i = QUOTA_WINDOW_ORDER.indexOf(name);
+    return i === -1 ? QUOTA_WINDOW_ORDER.length : i;
+  };
+  return (windows || [])
+    .filter(w => w && !isEmptyUnknown(w))
+    .map((window, i) => ({ window, i }))
+    .sort((a, b) => rank(a.window.name) - rank(b.window.name) || a.i - b.i)
+    .map(entry => entry.window);
+}

--- a/test/quota-windows.test.mjs
+++ b/test/quota-windows.test.mjs
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { quotaWindowLabel, orderQuotaWindows } from '../src/client/shared/quota.js';
+
+// The exact payload the Anthropic endpoint started returning.
+const LIVE = [
+  { name: 'nimbus_quill', utilization: 0, resetsAt: null },
+  { name: 'five_hour', utilization: 0.18, resetsAt: '2026-08-15T14:09:59Z' },
+  { name: 'seven_day', utilization: 0.08, resetsAt: '2026-08-17T05:59:59Z' }
+];
+
+test('known windows keep their Chinese labels', () => {
+  assert.equal(quotaWindowLabel('five_hour'), '5 小时');
+  assert.equal(quotaWindowLabel('seven_day'), '7 天');
+  assert.equal(quotaWindowLabel('seven_day_opus'), '7 天 · Opus');
+});
+
+test('an unknown window falls back to its raw name', () => {
+  assert.equal(quotaWindowLabel('nimbus_quill'), 'nimbus_quill');
+});
+
+test('an unknown empty window never displaces a real one', () => {
+  // Regression: indexOf returned -1 for nimbus_quill, sorting it ahead of
+  // five_hour (0), and the card's slice(0, 2) then dropped seven_day.
+  const ordered = orderQuotaWindows(LIVE);
+  assert.deepEqual(ordered.map(w => w.name), ['five_hour', 'seven_day']);
+  assert.deepEqual(ordered.slice(0, 2).map(w => w.name), ['five_hour', 'seven_day']);
+});
+
+test('known windows sort into the declared order regardless of input order', () => {
+  const shuffled = [
+    { name: 'seven_day_sonnet', utilization: 0.1, resetsAt: 'x' },
+    { name: 'seven_day', utilization: 0.2, resetsAt: 'x' },
+    { name: 'five_hour', utilization: 0.3, resetsAt: 'x' }
+  ];
+  assert.deepEqual(
+    orderQuotaWindows(shuffled).map(w => w.name),
+    ['five_hour', 'seven_day', 'seven_day_sonnet']
+  );
+});
+
+test('an unknown window with real usage is kept, but ranked last', () => {
+  const withData = [
+    { name: 'future_window', utilization: 0.5, resetsAt: '2026-09-01T00:00:00Z' },
+    { name: 'five_hour', utilization: 0.1, resetsAt: 'x' }
+  ];
+  assert.deepEqual(
+    orderQuotaWindows(withData).map(w => w.name),
+    ['five_hour', 'future_window']
+  );
+});
+
+test('unknown windows hold their relative order behind the known ones', () => {
+  const many = [
+    { name: 'beta_two', utilization: 0.2, resetsAt: 'x' },
+    { name: 'beta_one', utilization: 0.3, resetsAt: 'x' },
+    { name: 'seven_day', utilization: 0.1, resetsAt: 'x' }
+  ];
+  assert.deepEqual(
+    orderQuotaWindows(many).map(w => w.name),
+    ['seven_day', 'beta_two', 'beta_one']
+  );
+});
+
+test('empty and malformed input does not throw', () => {
+  assert.deepEqual(orderQuotaWindows([]), []);
+  assert.deepEqual(orderQuotaWindows(null), []);
+  assert.deepEqual(orderQuotaWindows(undefined), []);
+  assert.deepEqual(orderQuotaWindows([null, undefined]), []);
+});


### PR DESCRIPTION
Reported as "why is it in English now" — the Claude quota card was showing `nimbus_quill`. It turned out the English label was the smaller half of the problem.

## What the API actually returns

```
nimbus_quill  utilization=0     resetsAt=null      <- new, undocumented
five_hour     utilization=0.18  resetsAt=2026-08-15T14:09:59Z
seven_day     utilization=0.08  resetsAt=2026-08-17T05:59:59Z
```

## Two defects, one root cause

1. **Cosmetic.** `QUOTA_WINDOW_LABEL[name] || name` has no entry for `nimbus_quill`, so the card printed the raw vendor codename.

2. **Functional, and the real damage.** The sort ranked windows by `QUOTA_WINDOW_ORDER.indexOf(name)`, which returns **−1** for an unknown name — lower than `five_hour`'s `0`. So the unknown window sorted to the *front*, and the card's `.slice(0, 2)` then dropped **`seven_day` (8%) entirely**. A real limit vanished from the UI. That matches the report: the Claude card showed `nimbus_quill 0%` and `5 小时 18%`, with no 7-day row, while Codex still had its own.

## Fix

Labelling and ordering move into `src/client/shared/quota.js`:

- Unknown names rank **after** every known one (`indexOf === -1` → `length`), so they can never take a slot from a real limit.
- An unrecognised window carrying **neither a reset time nor any usage** is a vendor placeholder, not something the user is spending against, and is dropped. This is a property check, not a hardcoded `nimbus_quill` match — an unknown window that *does* have real data is still shown, just last.
- Unknown windows keep their relative order behind the known ones.

## Verification

`test/quota-windows.test.mjs` — 7 cases, built from the live payload above. Confirmed they catch the original bug: re-injecting the old `indexOf` ranking and dropping the placeholder filter fails 3 of them; restoring the fix passes all 7.

Browser check against live data after the fix:

```json
[{"tool":"Claude","windows":[
   {"name":"5 小时","reset":"4h33m 后重置","pct":"21%"},
   {"name":"7 天","reset":"1d20h 后重置","pct":"8%"}]},
 {"tool":"Codex","windows":[
   {"name":"7 天","reset":"4d18h 后重置","pct":"100%"}]}]
```

`npm test` 59/59, `npm run build` clean.